### PR TITLE
Reject duplicates when deserializing ops, args, and leases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod client;
 pub mod common;
 pub mod server;
 pub mod syntax;
+pub(crate) mod serde_helpers;
 
 #[cfg(test)]
 mod test {

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use indexmap::{map::Entry, IndexMap};
+use serde::de::{Deserialize, Deserializer, Error, MapAccess, Visitor};
+use std::fmt;
+use std::hash::{BuildHasher, Hash};
+use std::marker::PhantomData;
+
+// Helper function to deserialize an `IndexMap` while failing if duplicate keys
+// are encountered.
+//
+// The implementation is heavily derived from
+// #[https://docs.rs/serde_with/1.11.0/serde_with/rust/maps_duplicate_key_is_error],
+// which only supports the built-in std maps (enforced by a sealed trait). We
+// hard-code `IndexMap` here instead of being more generic; we also require the
+// key type to implement `Debug` so we can report the duplicated key in our
+// error message.
+pub(crate) fn deserialize_reject_dup_keys<'de, D, K, V, S>(
+    deserializer: D,
+) -> Result<IndexMap<K, V, S>, D::Error>
+where
+    D: Deserializer<'de>,
+    K: Deserialize<'de> + Hash + Eq + fmt::Debug,
+    V: Deserialize<'de>,
+    S: BuildHasher + Default,
+{
+    let visitor = MapVisitor {
+        key_type: PhantomData,
+        value_type: PhantomData,
+        state_type: PhantomData,
+    };
+    deserializer.deserialize_map(visitor)
+}
+
+struct MapVisitor<K, V, S> {
+    key_type: PhantomData<K>,
+    value_type: PhantomData<V>,
+    state_type: PhantomData<S>,
+}
+
+impl<'de, K, V, S> Visitor<'de> for MapVisitor<K, V, S>
+where
+    K: Deserialize<'de> + Hash + Eq + fmt::Debug,
+    V: Deserialize<'de>,
+    S: BuildHasher + Default,
+{
+    type Value = IndexMap<K, V, S>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a map")
+    }
+
+    fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = match access.size_hint() {
+            Some(size) => {
+                Self::Value::with_capacity_and_hasher(size, S::default())
+            }
+            None => Self::Value::with_hasher(S::default()),
+        };
+
+        while let Some((key, value)) = access.next_entry()? {
+            match values.entry(key) {
+                Entry::Occupied(slot) => {
+                    return Err(Error::custom(format_args!(
+                        "invalid entry: found duplicate key {:?}",
+                        slot.key()
+                    )));
+                }
+                Entry::Vacant(slot) => {
+                    slot.insert(value);
+                }
+            }
+        }
+
+        Ok(values)
+    }
+}

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -23,6 +23,9 @@ pub struct Interface {
     ///
     /// This is an `IndexMap`, and the order of declaration of the operations is
     /// significant -- it determines the operation numbering.
+    #[serde(
+        deserialize_with = "crate::serde_helpers::deserialize_reject_dup_keys"
+    )]
     pub ops: IndexMap<String, Operation>,
 }
 
@@ -51,14 +54,20 @@ pub struct Operation {
     /// The order of arguments is significant, it determines the packing order.
     /// Because this means that ergonomics changes to the API can affect runtime
     /// performance, we may want a way to override this eventually (TODO).
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_reject_dup_keys"
+    )]
     pub args: IndexMap<String, AttributedTy>,
     /// Arguments of the operation that are converted into leases. If omitted,
     /// zero leases are assumed.
     ///
     /// The order of leases is significant, as it determines their numerical
-    /// index from the server's perspective.
-    #[serde(default)]
+    /// index from the jerver's perspective.
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_helpers::deserialize_reject_dup_keys"
+    )]
     pub leases: IndexMap<String, Lease>,
     /// Expected type of the response.
     pub reply: Reply,
@@ -292,5 +301,113 @@ pub enum RecvStrategy {
 impl Default for RecvStrategy {
     fn default() -> Self {
         Self::FromBytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reject_duplicate_ops() {
+        const HAS_DUPES: &str = r#"
+            Interface(
+                name: "Spi",
+                ops: {
+                    "exchange": (
+                        args: {
+                            "device_index": (type: "u8"),
+                        },
+                        reply: Result(
+                            ok: "()",
+                            err: CLike("SpiError"),
+                        ),
+                    ),
+                    "lock": (
+                        args: {
+                            "device_index": (type: "u8"),
+                        },
+                        reply: Result(
+                            ok: "()",
+                            err: CLike("SpiError"),
+                        ),
+                    ),
+                    "exchange": (
+                        args: {
+                            "device_index": (type: "u8"),
+                        },
+                        reply: Result(
+                            ok: "()",
+                            err: CLike("SpiError"),
+                        ),
+                    ),
+                },
+            )
+        "#;
+
+        let err = Interface::from_str(HAS_DUPES).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid entry: found duplicate key \"exchange\""
+        );
+    }
+
+    #[test]
+    fn reject_duplicate_args() {
+        const HAS_DUPES: &str = r#"
+            Interface(
+                name: "Spi",
+                ops: {
+                    "exchange": (
+                        args: {
+                            "foo": (type: "u8"),
+                            "bar": (type: "u8"),
+                            "foo": (type: "u8"),
+                        },
+                        reply: Result(
+                            ok: "()",
+                            err: CLike("SpiError"),
+                        ),
+                    ),
+                },
+            )
+        "#;
+
+        let err = Interface::from_str(HAS_DUPES).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid entry: found duplicate key \"foo\""
+        );
+    }
+
+    #[test]
+    fn reject_duplicate_leases() {
+        const HAS_DUPES: &str = r#"
+            Interface(
+                name: "Spi",
+                ops: {
+                    "exchange": (
+                        args: {
+                            "foo": (type: "u8"),
+                        },
+                        leases: {
+                            "source": (type: "[u8]", read: true),
+                            "sink": (type: "[u8]", write: true),
+                            "source": (type: "[u8]", read: true),
+                        },
+                        reply: Result(
+                            ok: "()",
+                            err: CLike("SpiError"),
+                        ),
+                    ),
+                },
+            )
+        "#;
+
+        let err = Interface::from_str(HAS_DUPES).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid entry: found duplicate key \"source\""
+        );
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -63,7 +63,7 @@ pub struct Operation {
     /// zero leases are assumed.
     ///
     /// The order of leases is significant, as it determines their numerical
-    /// index from the jerver's perspective.
+    /// index from the server's perspective.
     #[serde(
         default,
         deserialize_with = "crate::serde_helpers::deserialize_reject_dup_keys"


### PR DESCRIPTION
Adding support to `IndexMap` in `serde_with` itself would be even smaller than this PR (add an implementation of [`PreventDuplicateInsertsSet`](https://github.com/jonasbb/serde_with/blob/f9cbe9311df73cbb55fb5db85761d90d16b294a4/serde_with/src/duplicate_key_impls/error_on_duplicate.rs#L4-L9)), but I didn't pursue that for a couple reasons:

1. The docs and crate organization of `serde_with` itself imply that those extensions are specific to standard Rust types. Maybe the folks responsible would be fine with adding `IndexMap` support behind a cargo feature, but see point 2.
2. I thought it'd be nicer for the error message to contain the name of the duplicated key, which requires putting some kind of bound on it (I went with `Debug`). This is reasonable for idolatry's use where all the keys are strings, but wouldn't be reasonable for `serde_with`.

The tests might be overkill. I considered the following and was on the fence about them all, but would be happy to pursue one (or any other option):

* remove them now that it works
* cut back to just one instead of three
* move them from `syntax.rs` to `serde_helpers.rs` (possibly in addition to trimming to just one)

out of concern for annoyance in maintaining them in the future as the syntax changes.

Fixes #9.