### PR TITLE
Add `bool` support

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -201,6 +201,17 @@ you want:
 
 The value taken by `recv` is an enum so we can add more methods in the future.
 
+### Booleans as arguments
+As mentioned above, booleans are not normally valid for use with `zerocopy`.
+They also don't implement `From` or [`TryFrom`](https://github.com/rust-lang/rust/pull/50597),
+so the alternate `recv` strategies above don't work.
+
+Since `bool` is a common type, they are special-cased in Idol to pack into
+a single `u8`. The value is encoded with `false => 0, true => 1`, and
+decoded with `0 => false, * => true`. APIs which call into Idol functions
+without using the generated client API (e.g. [Humility](https://github.com/oxidecomputer/humility))
+must also implement this special-case behavior.
+
 [Hubris]: https://hubris.oxide.computer/
 [serde]: https://serde.rs/
 [RON]: https://docs.rs/ron/0.7.0/ron/

--- a/src/client.rs
+++ b/src/client.rs
@@ -169,7 +169,8 @@ pub fn generate_client_stub(
         match &op.reply {
             syntax::Reply::Simple(t) => {
                 match op.encoding {
-                    syntax::Encoding::Zerocopy | syntax::Encoding::Ssmarshal => {
+                    syntax::Encoding::Zerocopy
+                    | syntax::Encoding::Ssmarshal => {
                         // Both these encodings guarantee that sizeof is big
                         // enough.
                         writeln!(
@@ -182,7 +183,8 @@ pub fn generate_client_stub(
             }
             syntax::Reply::Result { ok, err } => {
                 match op.encoding {
-                    syntax::Encoding::Zerocopy | syntax::Encoding::Ssmarshal => {
+                    syntax::Encoding::Zerocopy
+                    | syntax::Encoding::Ssmarshal => {
                         // Both these encodings guarantee that sizeof is big
                         // enough.
                         writeln!(
@@ -236,7 +238,10 @@ pub fn generate_client_stub(
         writeln!(out, "            {}Operation::{} as u16,", iface.name, name)?;
         match op.encoding {
             syntax::Encoding::Zerocopy => {
-                writeln!(out, "            zerocopy::AsBytes::as_bytes(&args),")?;
+                writeln!(
+                    out,
+                    "            zerocopy::AsBytes::as_bytes(&args),"
+                )?;
             }
             syntax::Encoding::Ssmarshal => {
                 writeln!(out, "            &argsbuf[..arglen],")?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -161,10 +161,9 @@ pub fn generate_client_stub(
         for (argname, arg) in &op.args {
             // Special-case handling of `bool` values when using the Zerocopy
             // encoding strategy, for efficiency.
-            let ty_str = if arg.ty.0 == "bool" {
-                "u8"
-            } else {
-                arg.ty.0.as_str()
+            let ty_str = match arg.ty.0.as_str() {
+                "bool" => "u8",
+                ty => ty,
             };
 
             writeln!(out, "            {}: {},", argname, ty_str)?;
@@ -306,11 +305,10 @@ pub fn generate_client_stub(
                 }
                 match &t.recv {
                     syntax::RecvStrategy::FromBytes => {
-                        if t.ty.0 == "bool" {
-                            writeln!(out, "        v != 0")?;
-                        } else {
-                            writeln!(out, "        v")?;
-                        }
+                        match t.ty.0.as_str() {
+                            "bool" => writeln!(out, "        v != 0"),
+                            _ => writeln!(out, "        v"),
+                        }?;
                     }
                     syntax::RecvStrategy::From(_, None) => {
                         writeln!(out, "        v.into()")?;
@@ -351,11 +349,10 @@ pub fn generate_client_stub(
                 }
                 match &ok.recv {
                     syntax::RecvStrategy::FromBytes => {
-                        if ok.ty.0 == "bool" {
-                            writeln!(out, "            Ok(v != 0)")?;
-                        } else {
-                            writeln!(out, "            Ok(v)")?;
-                        }
+                        match ok.ty.0.as_str() {
+                            "bool" => writeln!(out, "            Ok(v != 0)"),
+                            _ => writeln!(out, "            Ok(v)"),
+                        }?;
                     }
                     syntax::RecvStrategy::From(_, None) => {
                         writeln!(out, "            Ok(v.into())")?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -57,7 +57,11 @@ pub fn generate_server_constants(
                 // be no larger than the size of the input types. So this method
                 // works for both.
                 for arg in op.args.values() {
-                    writeln!(out, "    + core::mem::size_of::<{}>()", arg.ty.0)?;
+                    writeln!(
+                        out,
+                        "    + core::mem::size_of::<{}>()",
+                        arg.ty.0
+                    )?;
                 }
             }
         }
@@ -67,20 +71,23 @@ pub fn generate_server_constants(
         match &op.reply {
             syntax::Reply::Result { ok, .. } => {
                 match op.encoding {
-                    syntax::Encoding::Zerocopy | syntax::Encoding::Ssmarshal => {
+                    syntax::Encoding::Zerocopy
+                    | syntax::Encoding::Ssmarshal => {
                         // This strategy only uses bytes for the OK side of the type,
                         // and only sends one type, so:
-                        writeln!(out, "core::mem::size_of::<{}>();", ok.display())?;
+                        writeln!(
+                            out,
+                            "core::mem::size_of::<{}>();",
+                            ok.display()
+                        )?;
                     }
                 }
             }
-            syntax::Reply::Simple(t) => {
-                match op.encoding {
-                    syntax::Encoding::Zerocopy | syntax::Encoding::Ssmarshal => {
-                        writeln!(out, "core::mem::size_of::<{}>();", t.display())?;
-                    }
+            syntax::Reply::Simple(t) => match op.encoding {
+                syntax::Encoding::Zerocopy | syntax::Encoding::Ssmarshal => {
+                    writeln!(out, "core::mem::size_of::<{}>();", t.display())?;
                 }
-            }
+            },
         }
 
         upper_names.push(upper_name);
@@ -115,10 +122,7 @@ pub fn generate_server_conversions(
                 )?;
             }
             syntax::Encoding::Ssmarshal => {
-                writeln!(
-                    out,
-                    "#[derive(Copy, Clone, serde::Deserialize)]"
-                )?;
+                writeln!(out, "#[derive(Copy, Clone, serde::Deserialize)]")?;
             }
         }
         writeln!(out, "pub struct {}_{}_ARGS {{", iface.name, name)?;
@@ -178,7 +182,10 @@ pub fn generate_server_conversions(
                 writeln!(out, "pub fn read_{}_msg(bytes: &[u8])", name)?;
                 writeln!(out, "    -> Option<{}_{}_ARGS>", iface.name, name)?;
                 writeln!(out, "{{")?;
-                writeln!(out, "    ssmarshal::deserialize(bytes).ok().map(|(x, _)| x)")?;
+                writeln!(
+                    out,
+                    "    ssmarshal::deserialize(bytes).ok().map(|(x, _)| x)"
+                )?;
                 writeln!(out, "}}")?;
             }
         }
@@ -215,12 +222,7 @@ pub fn generate_server_op_impl(
     writeln!(out, "        match self {{")?;
     // Note: if we start allowing optional leases this will have to get fancier.
     for (opname, op) in &iface.ops {
-        writeln!(
-            out,
-            "            Self::{} => {},",
-            opname,
-            op.leases.len(),
-        )?;
+        writeln!(out, "            Self::{} => {},", opname, op.leases.len(),)?;
     }
     writeln!(out, "        }}")?;
     writeln!(out, "    }}")?;
@@ -298,11 +300,7 @@ pub fn generate_server_in_order_trait(
                 write!(out, ">>")?;
             }
             syntax::Reply::Simple(t) => {
-                write!(
-                    out,
-                    " -> {}",
-                    t.display()
-                )?;
+                write!(out, " -> {}", t.display())?;
             }
         }
         writeln!(out, ";")?;
@@ -329,7 +327,10 @@ pub fn generate_server_in_order_trait(
     writeln!(out, "        op: {}Operation,", iface.name)?;
     writeln!(out, "        incoming: &[u8],")?;
     writeln!(out, "        rm: &userlib::RecvMessage,")?;
-    writeln!(out, "    ) -> Result<(), idol_runtime::RequestError<u16>> {{")?;
+    writeln!(
+        out,
+        "    ) -> Result<(), idol_runtime::RequestError<u16>> {{"
+    )?;
     writeln!(out, "        #[allow(unused_imports)]")?;
     writeln!(out, "        use core::convert::TryInto;")?;
     writeln!(out, "        use idol_runtime::ClientError;")?;
@@ -428,10 +429,7 @@ pub fn generate_server_in_order_trait(
                 writeln!(out, "                    }}")?;
                 writeln!(out, "                    Err(val) => {{")?;
                 // Simple returns can only return ClientError.
-                writeln!(
-                    out,
-                    "                        Err(val.into())"
-                )?;
+                writeln!(out, "                        Err(val.into())")?;
                 writeln!(out, "                    }}")?;
                 writeln!(out, "                }}")?;
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -520,9 +520,9 @@ static _{}_IDOL_DEFINITION: [u8; {}] = ["##,
         text.len()
     )?;
 
-    for i in 0..bytes.len() {
+    for (i, byte) in bytes.iter().enumerate() {
         let delim = if i % 10 == 0 { "\n    " } else { " " };
-        write!(out, "{}0x{:02x},", delim, bytes[i])?;
+        write!(out, "{}0x{:02x},", delim, byte)?;
     }
 
     writeln!(out, "\n];\n")?;

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -232,7 +232,7 @@ impl<'de> serde::de::Visitor<'de> for AttributedTyVisitor {
     {
         Ok(AttributedTy {
             ty: Ty(v.to_string()),
-            recv: Default::default(),
+            recv: RecvStrategy::default(),
         })
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -216,7 +216,8 @@ impl<'de> serde::de::Visitor<'de> for AttributedTyVisitor {
                 }
             }
         }
-        let ty = ty.ok_or_else(|| serde::de::Error::missing_field("type"))?;
+        let ty: Ty =
+            ty.ok_or_else(|| serde::de::Error::missing_field("type"))?;
         let recv = recv.unwrap_or_else(RecvStrategy::default);
         Ok(AttributedTy { ty, recv })
     }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -168,8 +168,10 @@ impl AttributedTy {
     pub fn repr_ty(&self) -> &str {
         match &self.recv {
             RecvStrategy::From(t, _) | RecvStrategy::FromPrimitive(t) => &t.0,
-            RecvStrategy::FromBytes => &self.ty.0,
-            RecvStrategy::BoolAsU8 => "u8",
+            RecvStrategy::FromBytes => match self.ty.0.as_str() {
+                "bool" => "u8",
+                ty => ty,
+            },
         }
     }
 }
@@ -219,7 +221,7 @@ impl<'de> serde::de::Visitor<'de> for AttributedTyVisitor {
         }
         let ty: Ty =
             ty.ok_or_else(|| serde::de::Error::missing_field("type"))?;
-        let recv = recv.unwrap_or_else(|| ty.default_recv_strategy());
+        let recv = recv.unwrap_or_else(Default::default);
         Ok(AttributedTy { ty, recv })
     }
 
@@ -227,9 +229,10 @@ impl<'de> serde::de::Visitor<'de> for AttributedTyVisitor {
     where
         E: serde::de::Error,
     {
-        let ty = Ty(v.to_string());
-        let recv = ty.default_recv_strategy();
-        Ok(AttributedTy { ty, recv })
+        Ok(AttributedTy {
+            ty: Ty(v.to_string()),
+            recv: Default::default(),
+        })
     }
 }
 
@@ -254,13 +257,6 @@ impl Ty {
     pub fn appears_unsized(&self) -> bool {
         // This is a hack. Need to work out a better way to determine this.
         self.0.starts_with('[') && self.0.ends_with(']')
-    }
-    /// Returns a default return strategy for the given type
-    pub fn default_recv_strategy(&self) -> RecvStrategy {
-        match self.0.as_str() {
-            "bool" => RecvStrategy::BoolAsU8,
-            _ => RecvStrategy::FromBytes,
-        }
     }
 }
 
@@ -295,8 +291,10 @@ pub enum RecvStrategy {
     /// If the second field is `Some(fn_name)`, it specifies conversion by
     /// `fn_name`.
     From(Ty, #[serde(default)] Option<String>),
-    /// The received bytes should be a single `u8` which is mapped to `true`
-    /// if nonzero and `false` otherwise.  This is only used when sending
-    /// `bool` values.
-    BoolAsU8,
+}
+
+impl Default for RecvStrategy {
+    fn default() -> Self {
+        Self::FromBytes
+    }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -26,13 +26,14 @@ pub struct Interface {
     pub ops: IndexMap<String, Operation>,
 }
 
-impl Interface {
+impl std::str::FromStr for Interface {
+    type Err = ron::Error;
     /// Converts the canonical text representation of an interface into an
     /// `Interface`.
     ///
     /// The canonical text representation is the Serde representation of
     /// `Interface` as encoded by RON.
-    pub fn from_str(text: &str) -> Result<Self, ron::Error> {
+    fn from_str(text: &str) -> Result<Self, ron::Error> {
         let iface: Self = ron::de::from_str(text)?;
         Ok(iface)
     }
@@ -221,7 +222,7 @@ impl<'de> serde::de::Visitor<'de> for AttributedTyVisitor {
         }
         let ty: Ty =
             ty.ok_or_else(|| serde::de::Error::missing_field("type"))?;
-        let recv = recv.unwrap_or_else(Default::default);
+        let recv = recv.unwrap_or_default();
         Ok(AttributedTy { ty, recv })
     }
 


### PR DESCRIPTION
This PR implements support for `bool` arguments in Idol APIs. It requires support from Humility, implemented in [this PR](https://github.com/oxidecomputer/humility/pull/112).  No APIs use this yet, so it's not a flag day.

Booleans are encoded as a single `u8` using the default `FromBytes` strategy. This is a _little_ awkward, since it's not quite `FromBytes`, but prevents invalid states (e.g. I previous considered added a `RecvStrategy::BoolAsU8`, but that was only valid iff `ty == "bool"`).