### PR TITLE
Use the size of args struct for deserializing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,15 @@
 
 pub mod client;
 pub mod common;
+pub(crate) mod serde_helpers;
 pub mod server;
 pub mod syntax;
-pub(crate) mod serde_helpers;
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use std::str::FromStr;
+
     const EXAMPLE: &str = r#"
         Interface(
             name: "Spi",
@@ -42,7 +44,7 @@ mod test {
 
     #[test]
     fn parse_example() {
-        let _iface = super::syntax::Interface::from_str(EXAMPLE)
+        let _iface = syntax::Interface::from_str(EXAMPLE)
             .expect("example failed to parse");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod serde_helpers;
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
     const EXAMPLE: &str = r#"
         Interface(
             name: "Spi",

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -312,6 +312,7 @@ impl Default for RecvStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn reject_duplicate_ops() {


### PR DESCRIPTION
`ssmarshal` guarantees that the serialized size is <= the size of the
input type, but that's not necessarily the same as the sum of individual
struct members in the input type, since we're not packing them.

We _could_ evaluate whether packing makes sense, but for now, this
makes the server match the client (which already allocated
`size_of::<Func_ARGS>()` for serialization).