### PR TITLE
Use ok_or_else to skip unnecessary function call

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -375,7 +375,7 @@ pub fn generate_server_in_order_trait(
         writeln!(out, "            {}Operation::{} => {{", iface.name, opname)?;
         writeln!(
             out,
-            "                let {}args = read_{}_msg(incoming).ok_or(ClientError::BadMessageContents.fail())?;",
+            "                let {}args = read_{}_msg(incoming).ok_or_else(|| ClientError::BadMessageContents.fail())?;",
             if op.args.is_empty() { "_" } else { "" },
             opname
         )?;
@@ -408,7 +408,7 @@ pub fn generate_server_in_order_trait(
                 syntax::RecvStrategy::FromPrimitive(_) => {
                     writeln!(
                         out,
-                        "                    args.{}().ok_or(ClientError::BadMessageContents.fail())?,",
+                        "                    args.{}().ok_or_else(|| ClientError::BadMessageContents.fail())?,",
                         argname
                     )?;
                 }
@@ -444,7 +444,7 @@ pub fn generate_server_in_order_trait(
                 ("", "".to_string())
             };
 
-            write!(out, "                    idol_runtime::Leased::{}{}(rm.sender, {}{}).ok_or(ClientError::BadLease.fail())?", fun, suffix, i, limit)?;
+            write!(out, "                    idol_runtime::Leased::{}{}(rm.sender, {}{}).ok_or_else(|| ClientError::BadLease.fail())?", fun, suffix, i, limit)?;
             if lease.max_len.is_some() {
                 write!(out, ".try_into().unwrap_lite()")?;
             }


### PR DESCRIPTION
This eliminates Clippy warnings from the generated code.