### PR TITLE
Allow leases of type other than [u8]

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -277,7 +277,7 @@ pub fn generate_client_stub(
             };
             writeln!(
                 out,
-                "                userlib::Lease::{}(arg_{}),",
+                "                userlib::Lease::{}(zerocopy::AsBytes::as_bytes(arg_{})),",
                 ctor, leasename
             )?;
         }


### PR DESCRIPTION
Non-[u8] leases seem to work fine, but the generated client code doesn't
handle them properly. This change allows leases of any type that
implement zerocopy::{AsBytes, FromBytes}.