### PR TITLE
Client support for non-u8 lease types.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -273,16 +273,16 @@ pub fn generate_client_stub(
         writeln!(out, "            &mut reply,")?;
         writeln!(out, "            &[")?;
         for (leasename, lease) in &op.leases {
-            let ctor = match (lease.read, lease.write) {
-                (true, true) => "read_write",
-                (false, true) => "write_only",
-                (true, false) => "read_only",
+            let (ctor, asbytes) = match (lease.read, lease.write) {
+                (true, true) => ("read_write", "as_bytes_mut"),
+                (false, true) => ("write_only", "as_bytes_mut"),
+                (true, false) => ("read_only", "as_bytes"),
                 (false, false) => panic!("should have been caught above"),
             };
             writeln!(
                 out,
-                "                userlib::Lease::{}(arg_{}),",
-                ctor, leasename
+                "                userlib::Lease::{}(zerocopy::AsBytes::{}(arg_{})),",
+                ctor, asbytes, leasename
             )?;
         }
         writeln!(out, "            ],")?;


### PR DESCRIPTION
The server-side runtime support has attempted to allow non-u8 lease types since the beginning, but the client-side code generator is, uh, more grown than designed. :-) This alters it to pass leased buffers through zerocopy::AsBytes, allowing any type that implements the appropriate zerocopy traits to be used.

Thanks to Github user @pokeylope for pointing this out and sending an initial version of this commit.