### PR TITLE
Add Encoding::Hubpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "idol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "indexmap",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -90,8 +90,13 @@ pub enum Encoding {
     /// cheapest but won't work for complex types.
     Zerocopy,
     /// Encode types using the `ssmarshal` codec for `serde`. This can transfer
-    /// arbitrarily complex Rust types.
+    /// complex Rust types, but has strict rules about the formation of those
+    /// types that are _not_ checked at compile time. Prefer `Hubpack`.
     Ssmarshal,
+    /// Encode types using the `hubpack` codec for `serde`. This can transfer
+    /// complex Rust types. It has strict rules about the formation of those
+    /// types, but all those rules are checked at compile time.
+    Hubpack,
 }
 
 impl Default for Encoding {


### PR DESCRIPTION
Example of a generated client stub for an idempotent operation with a single `u64` arg:

```rust
    // operation: get_reset_reason2 (4)
    // idempotent - will auto-retry
    pub fn get_reset_reason2(
        &self,
        foo: u64,
    ) -> ComboResetReason {
        let (arg_foo,) = (foo,);
        #[allow(non_camel_case_types)]
        #[derive(serde::Serialize, hubpack::SerializedSize)]
        struct Jefe_get_reset_reason2_ARGS {
            foo: u64,
        }

        const REPLY_SIZE: usize = {
            <ComboResetReason as hubpack::SerializedSize>::MAX_SIZE
        };

        let args = Jefe_get_reset_reason2_ARGS {
            foo: arg_foo,
        };

        let mut argsbuf = [0; <Jefe_get_reset_reason2_ARGS as hubpack::SerializedSize>::MAX_SIZE];
        let arglen = hubpack::serialize(&mut argsbuf, &args).unwrap_lite();
        let mut reply = [0u8; REPLY_SIZE];

        loop {
        let task = self.current_id.get();

        let (rc, len) = sys_send(
            task,
            JefeOperation::get_reset_reason2 as u16,
            &argsbuf[..arglen],
            &mut reply,
            &[
            ],
        );
        if let Some(g) = userlib::extract_new_generation(rc) {
            self.current_id.set(userlib::TaskId::for_index_and_gen(task.index(), g));
            continue;
        }
        if rc != 0 { panic!(); }
        let (v, _): (ComboResetReason, _) = hubpack::deserialize(&reply[..len]).unwrap_lite();
        return v;
        }
    }
```

and the relevant bits from the corresponding server stub:

```rust
pub const GET_RESET_REASON2_MSG_SIZE: usize =
    <Jefe_get_reset_reason2_ARGS as hubpack::SerializedSize>::MAX_SIZE;
pub const GET_RESET_REASON2_REPLY_SIZE: usize =<ComboResetReason as hubpack::SerializedSize>::MAX_SIZE;

// ...

pub fn read_get_reset_reason2_msg(bytes: &[u8])
    -> Option<Jefe_get_reset_reason2_ARGS>
{
    hubpack::deserialize(bytes).ok().map(|(x, _)| x)
}

// ...

            JefeOperation::get_reset_reason2 => {
                let args = read_get_reset_reason2_msg(incoming).ok_or_else(|| ClientError::BadMessageContents.fail())?;
                let r = self.1.get_reset_reason2(
                    rm,
                    args.foo,
                );
                match r {
                    Ok(val) => {
                        let mut reply_buf = [0u8; GET_RESET_REASON2_REPLY_SIZE];
                        let n_reply = hubpack::serialize(&mut reply_buf, &val).map_err(|_| ()).unwrap_lite();
                        userlib::sys_reply(rm.sender, 0, &reply_buf[..n_reply]);
                        Ok(())
                    }
                    Err(val) => Err(val.map_runtime(|e| match e { })),
                }
            }
```