### PR TITLE
Add BufReader/Writer and supporting traits

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1024,38 +1024,3 @@ impl<'a> From<&'a mut [u8]> for SliceBufWriter<'a> {
         SliceBufWriter { data, index: 0 }
     }
 }
-
-/// A `Lease` with an attached size hint for `LeaseBufReader/Writer`
-///
-/// This allows us to write functions that work on either slices or leases!
-///
-/// Such a function should be generic across `R: BufReader, B: Into<R>`,
-/// with either
-///
-/// - `R` is `SliceBufReader`, `B` is `&[u8]`
-/// - `R` is `LeaseBufReader<BUFSIZ>`, `B` is `BufSizeHint<R, BUFSIZ>`
-///
-/// (and the same for `BufWriter`)
-pub struct BufSizeHint<A: Attribute, const B: usize>(Leased<A, [u8]>);
-
-impl<A: Attribute, const B: usize> From<Leased<A, [u8]>> for BufSizeHint<A, B> {
-    fn from(lease: Leased<A, [u8]>) -> Self {
-        Self(lease)
-    }
-}
-
-impl<'a, A: AttributeRead, const BUFSIZ: usize> From<BufSizeHint<A, BUFSIZ>>
-    for LeaseBufReader<A, BUFSIZ>
-{
-    fn from(lease: BufSizeHint<A, BUFSIZ>) -> Self {
-        LeaseBufReader::from(lease.0)
-    }
-}
-
-impl<'a, A: AttributeWrite, const BUFSIZ: usize> From<BufSizeHint<A, BUFSIZ>>
-    for LeaseBufWriter<A, BUFSIZ>
-{
-    fn from(lease: BufSizeHint<A, BUFSIZ>) -> Self {
-        LeaseBufWriter::from(lease.0)
-    }
-}


### PR DESCRIPTION
This is a pre-requisite for letting Hubris code be generic across slices and leases.

I added a new `BufReader` trait, which is implemented for both the existing `LeaseBufReader` and a new `SliceBufReader`; the same goes for `BufWriter` / `SliceBufWriter`.

This allows us to write code of the form
```rust
    pub fn read_one<'b, BufWrite: BufWriter<'b>, Write: Into<BufWrite> + 'b>(
        &self,
        dest: Write,
    ) -> Result<(), ()> {
        let dest: BufWrite = dest.into();
        dest.write(1)
    }
```