### PR TITLE
Make NotificationHandler required, remove dispatch_n.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "idol"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "indexmap",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idol"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/server.rs
+++ b/src/server.rs
@@ -374,7 +374,7 @@ pub fn generate_server_in_order_trait(
 
     let trt = format!("InOrder{}Impl", iface.name);
 
-    writeln!(out, "pub trait {} {{", trt)?;
+    writeln!(out, "pub trait {}: idol_runtime::NotificationHandler {{", trt)?;
     writeln!(
         out,
         "    fn recv_source(&self) -> Option<userlib::TaskId> {{"


### PR DESCRIPTION
We ran into an issue last week where we inadvertently replaced a call to `idol_runtime::dispatch_n` with a call to `idol_runtime::dispatch`. This difficult-to-spot two-character change has the following implications:

1. No warnings or errors are produced.
2. Notifications to the server are silently ignored.

This is bad, and caused real failures in host startup.

This change alters the API to eliminate `dispatch_n` and make notification handling mandatory for all Idol servers -- to opt out of receiving notifications, they must explicitly implement `NotificationHandler` as stubs. This should prevent this class of error from reoccurring, and has the added benefit of simplifying the runtime implementation -- which I'd previously complicated in a misguided attempt at ergonomics.