### PR TITLE
introduce `Generator` type for configuring codegen

### DIFF
--- a/src/bin/clienttest.rs
+++ b/src/bin/clienttest.rs
@@ -10,7 +10,8 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let iface: idol::syntax::Interface = ron::de::from_str(&text)?;
 
-    idol::client::generate_client_stub(&iface, std::io::stdout())?;
+    idol::Generator::default()
+        .generate_client_stub(&iface, std::io::stdout())?;
 
     Ok(())
 }

--- a/src/bin/servertest.rs
+++ b/src/bin/servertest.rs
@@ -6,11 +6,12 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let iface: idol::syntax::Interface = ron::de::from_str(&text)?;
 
-    let tokens = idol::server::generate_restricted_server_support(
-        &iface,
-        idol::server::ServerStyle::InOrder,
-        &Default::default(),
-    )?;
+    let tokens = idol::Generator::default()
+        .generate_restricted_server_support(
+            &iface,
+            idol::server::ServerStyle::InOrder,
+            &Default::default(),
+        )?;
     let syntax_tree = syn::parse2::<syn::File>(tokens)?;
     let formatted = prettyplease::unparse(&syntax_tree);
     println!("{formatted}");

--- a/src/client.rs
+++ b/src/client.rs
@@ -86,12 +86,12 @@ impl Generator {
                 }
                 match &op.reply {
                     syntax::Reply::Result { err, .. }
-                        if matches!(err, syntax::Error::ServerDeath) =>
+                        if matches!(err, syntax::Error::ServerDeath) => 
                     {
                         return Err(
-                        format!("idempotent operations should not indicate server death: {name}")
-                            .into(),
-                    );
+                            format!("idempotent operations should not indicate server death: {name}")
+                                .into(),
+                        );
                     }
                     _ => (),
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{common, syntax};
+use super::{common, syntax, Generator};
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::env;
@@ -13,292 +13,322 @@ pub fn build_client_stub(
     source: &str,
     stub_name: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    let stub_file = File::create(out.join(stub_name)).unwrap();
-
-    generate_client_stub_from_file(source, stub_file)?;
-    println!("cargo:rerun-if-changed={}", source);
-    Ok(())
+    Generator::default().build_client_stub(source, stub_name)
 }
 
 pub fn generate_client_stub_from_file(
     source: impl AsRef<std::path::Path>,
     out: impl std::io::Write,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let text = std::fs::read_to_string(source)?;
-    let iface: syntax::Interface = ron::de::from_str(&text)?;
-    generate_client_stub(&iface, out)
+    Generator::default().generate_client_stub_from_file(source, out)
 }
 
 pub fn generate_client_stub(
     iface: &syntax::Interface,
-    mut out: impl std::io::Write,
+    out: impl std::io::Write,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let mut tokens = common::generate_op_enum(iface);
-    tokens.extend(client_stub_tokens(iface)?);
-    let formatted = common::fmt_tokens(tokens)?;
-    write!(out, "{formatted}")?;
-    Ok(())
+    Generator::default().generate_client_stub(iface, out)
 }
 
-fn client_stub_tokens(
-    iface: &syntax::Interface,
-) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
-    let mut ops = Vec::with_capacity(iface.ops.len());
-    let iface_name = &iface.name;
-    for (idx, (name, op)) in iface.ops.iter().enumerate() {
-        // Let's do some checks
-        if op.idempotent {
-            // An idempotent operation with a read-write lease seems like a
-            // problem, since it could forward half-initialized state from one
-            // instance of the server to the next, potentially propagating the
-            // crash; we could potentially handle it but for now, we'll reject
-            // it.
-            if op.leases.values().any(|lease| lease.read && lease.write) {
-                return Err("idempotent operation with read/write lease".into());
-            }
-            match &op.reply {
-                syntax::Reply::Result { err, .. }
-                    if matches!(err, syntax::Error::ServerDeath) =>
-                {
+impl Generator {
+    pub fn build_client_stub(
+        &self,
+        source: &str,
+        stub_name: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        let stub_file = File::create(out.join(stub_name)).unwrap();
+        self.generate_client_stub_from_file(source, stub_file)?;
+        println!("cargo:rerun-if-changed={}", source);
+        Ok(())
+    }
+
+    pub fn generate_client_stub_from_file(
+        &self,
+        source: impl AsRef<std::path::Path>,
+        out: impl std::io::Write,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let text = std::fs::read_to_string(source)?;
+        let iface: syntax::Interface = ron::de::from_str(&text)?;
+        self.generate_client_stub(&iface, out)
+    }
+
+    pub fn generate_client_stub(
+        &self,
+        iface: &syntax::Interface,
+        mut out: impl std::io::Write,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let mut tokens = common::generate_op_enum(iface);
+        tokens.extend(self.client_stub_tokens(iface)?);
+        let formatted = common::fmt_tokens(tokens)?;
+        write!(out, "{formatted}")?;
+        Ok(())
+    }
+
+    fn client_stub_tokens(
+        &self,
+        iface: &syntax::Interface,
+    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        let mut ops = Vec::with_capacity(iface.ops.len());
+        let iface_name = &iface.name;
+        for (idx, (name, op)) in iface.ops.iter().enumerate() {
+            // Let's do some checks
+            if op.idempotent {
+                // An idempotent operation with a read-write lease seems like a
+                // problem, since it could forward half-initialized state from one
+                // instance of the server to the next, potentially propagating the
+                // crash; we could potentially handle it but for now, we'll reject
+                // it.
+                if op.leases.values().any(|lease| lease.read && lease.write) {
                     return Err(
+                        "idempotent operation with read/write lease".into()
+                    );
+                }
+                match &op.reply {
+                    syntax::Reply::Result { err, .. }
+                        if matches!(err, syntax::Error::ServerDeath) =>
+                    {
+                        return Err(
                         format!("idempotent operations should not indicate server death: {name}")
                             .into(),
                     );
+                    }
+                    _ => (),
                 }
-                _ => (),
-            }
-        } else {
-            // A non-idempotent operation had better have an error type.
-            match &op.reply {
-                syntax::Reply::Result { .. } => (),
-                syntax::Reply::Simple(_) => {
-                    return Err(format!(
-                        "operation can't indicate server death: {name}",
-                    )
-                    .into());
-                }
-            }
-        }
-
-        let idempotent = if op.idempotent {
-            quote! {
-                /// idempotent - will auto-retry
-            }
-        } else {
-            quote! {
-                /// not idempotent, error type must represent death
-            }
-        };
-        let operation = format!(" operation: {name} ({idx})");
-        let args = op.args.iter().map(|(name, arg)| {
-            let ty = &arg.ty;
-            quote! {
-                #name: #ty
-            }
-        });
-        let leases = op.leases.iter().map(|(name, lease)| {
-            let reftype = if lease.write {
-                quote! { &mut }
-            } else if lease.read {
-                quote! { & }
             } else {
-                panic!("lease {name} grants no access");
-            };
-            let ty = &lease.ty;
-            quote! {
-                #name: #reftype #ty
-            }
-        });
-        let reply_ty = match &op.reply {
-            syntax::Reply::Result { ok, err } => {
-                let err = match err {
-                    syntax::Error::CLike(ty) | syntax::Error::Complex(ty) => {
-                        quote! { #ty }
+                // A non-idempotent operation had better have an error type.
+                match &op.reply {
+                    syntax::Reply::Result { .. } => (),
+                    syntax::Reply::Simple(_) => {
+                        return Err(format!(
+                            "operation can't indicate server death: {name}",
+                        )
+                        .into());
                     }
-                    syntax::Error::ServerDeath => {
-                        quote! { idol_runtime::ServerDeath }
-                    }
-                };
-                quote! { Result<#ok, #err> }
+                }
             }
-            syntax::Reply::Simple(t) => {
-                quote! { #t }
-            }
-        };
-        // Map the args with user-chosen names, which are good for rustdoc, into
-        // args with names that are guaranteed not to collide with our generated
-        // identifiers.
-        let argmap = {
-            let argnames = {
-                let args = op.args.keys().map(syntax::Name::arg_prefixed);
-                let leases = op.leases.keys().map(syntax::Name::arg_prefixed);
-                args.chain(leases)
-            };
-            let argvals = op.args.keys().chain(op.leases.keys());
-            quote! {
-                let (
-                    #(#argnames),*
-                ) = (
-                    #(#argvals),*
-                );
-            }
-        };
 
-        // Perform lease validation.
-        let lease_validators =
-            op.leases.iter().filter_map(|(leasename, lease)| {
-                // cast to usize here is load bearing, because `quote` will
-                // suffix this with `{n}u32` when interpolating, but `.len()`
-                // returns a `usize`. blah!
-                let n = lease.max_len?.get() as usize;
-                let argname = leasename.arg_prefixed();
-                // Note: we're not generating a panic message in the client to
-                // save ROM space. If the user chases the line number into the
-                // client stub source file the error should be clear.
-                Some(quote! {
-                    if #argname.len() > #n {
-                        panic!();
-                    }
-                })
-            });
-
-        // Define args struct.
-        let arg_struct_name =
-            quote::format_ident!("{}_{name}_ARGS", iface.name);
-        let arg_struct = {
-            let attrs = match op.encoding {
-                syntax::Encoding::Zerocopy => {
-                    quote! {
-                        #[derive(zerocopy::AsBytes)]
-                        #[repr(C, packed)]
-                    }
-                }
-                syntax::Encoding::Ssmarshal => {
-                    quote! {
-                        #[derive(serde::Serialize)]
-                    }
-                }
-                syntax::Encoding::Hubpack => {
-                    quote! {
-                        #[derive(serde::Serialize, hubpack::SerializedSize)]
-                    }
-                }
-            };
-            let fields = op.args.iter().map(|(argname, arg)| {
-                let ty = if arg.ty.is_bool() {
-                    quote! { u8 }
-                } else {
-                    quote! { #arg }
-                };
+            let idempotent = if op.idempotent {
                 quote! {
-                    #argname: #ty
+                    /// idempotent - will auto-retry
+                }
+            } else {
+                quote! {
+                    /// not idempotent, error type must represent death
+                }
+            };
+            let operation = format!(" operation: {name} ({idx})");
+            let args = op.args.iter().map(|(name, arg)| {
+                let ty = &arg.ty;
+                quote! {
+                    #name: #ty
                 }
             });
-            quote! {
-                #[allow(non_camel_case_types)]
-                #attrs
-                struct #arg_struct_name {
-                    #( #fields ),*
+            let leases = op.leases.iter().map(|(name, lease)| {
+                let reftype = if lease.write {
+                    quote! { &mut }
+                } else if lease.read {
+                    quote! { & }
+                } else {
+                    panic!("lease {name} grants no access");
+                };
+                let ty = &lease.ty;
+                quote! {
+                    #name: #reftype #ty
                 }
-            }
-        };
-
-        // Determine required size of reply buffer.
-        fn size_expr(
-            encoding: &syntax::Encoding,
-            ty: &syntax::AttributedTy,
-        ) -> TokenStream {
-            match encoding {
-                syntax::Encoding::Zerocopy | syntax::Encoding::Ssmarshal => {
-                    // Both these encodings guarantee that sizeof is big
-                    // enough.
-                    quote! { core::mem::size_of::<#ty>() }
-                }
-                syntax::Encoding::Hubpack => {
-                    quote! { <#ty as hubpack::SerializedSize>::MAX_SIZE }
-                }
-            }
-        }
-        let reply_size = {
-            let size = match &op.reply {
-                syntax::Reply::Simple(t) => size_expr(&op.encoding, t),
+            });
+            let reply_ty = match &op.reply {
                 syntax::Reply::Result { ok, err } => {
-                    let oksize = size_expr(&op.encoding, ok);
-                    let errsize = match err {
-                        syntax::Error::CLike(_)
-                        | syntax::Error::ServerDeath => {
-                            quote! { 0 }
+                    let err = match err {
+                        syntax::Error::CLike(ty)
+                        | syntax::Error::Complex(ty) => {
+                            quote! { #ty }
                         }
-                        syntax::Error::Complex(ty) => {
-                            quote! { <#ty as hubpack::SerializedSize>::MAX_SIZE; }
+                        syntax::Error::ServerDeath => {
+                            quote! { idol_runtime::ServerDeath }
                         }
                     };
-                    quote! {
-                        let oksize = #oksize;
-                        let errsize = #errsize;
-                        if oksize > errsize { oksize } else { errsize }
-                    }
+                    quote! { Result<#ok, #err> }
+                }
+                syntax::Reply::Simple(t) => {
+                    quote! { #t }
                 }
             };
-            quote! {
-                const REPLY_SIZE: usize = {
-                    #size
+            // Map the args with user-chosen names, which are good for rustdoc, into
+            // args with names that are guaranteed not to collide with our generated
+            // identifiers.
+            let argmap = {
+                let argnames = {
+                    let args = op.args.keys().map(syntax::Name::arg_prefixed);
+                    let leases =
+                        op.leases.keys().map(syntax::Name::arg_prefixed);
+                    args.chain(leases)
                 };
-            }
-        };
-
-        // Create instance of args struct from args.
-        let mk_arg_struct = {
-            let initializers = op.args.iter().map(|(argname, arg)| {
-                let arg_argname = argname.arg_prefixed();
-                if arg.ty.is_bool() {
-                    // Special case: we send booleans as non-zero u8, so that
-                    // we can use them in Zerocopy situations
-                    quote! { #argname: #arg_argname as u8 }
-                } else {
-                    quote! { #argname: #arg_argname }
-                }
-            });
-            let encoding_prep = match op.encoding {
-                syntax::Encoding::Zerocopy => {
-                    // No further prep required.
-                    quote! {}
-                }
-                syntax::Encoding::Ssmarshal => {
-                    // Serialize the arguments.
-                    quote! {
-                        let mut argsbuf = [0; core::mem::size_of::<#arg_struct_name>()];
-                        let arglen = ssmarshal::serialize(&mut argsbuf, &args).unwrap_lite();
-                    }
-                }
-                syntax::Encoding::Hubpack => {
-                    // Serialize the arguments.
-                    quote! {
-                        let mut argsbuf = [0; <#arg_struct_name as hubpack::SerializedSize>::MAX_SIZE];
-                        let arglen = hubpack::serialize(&mut argsbuf, &args).unwrap_lite();
-                    }
+                let argvals = op.args.keys().chain(op.leases.keys());
+                quote! {
+                    let (
+                        #(#argnames),*
+                    ) = (
+                        #(#argvals),*
+                    );
                 }
             };
-            quote! {
-                let args = #arg_struct_name {
-                    #( #initializers ),*
+
+            // Perform lease validation.
+            let lease_validators =
+                op.leases.iter().filter_map(|(leasename, lease)| {
+                    // cast to usize here is load bearing, because `quote` will
+                    // suffix this with `{n}u32` when interpolating, but `.len()`
+                    // returns a `usize`. blah!
+                    let n = lease.max_len?.get() as usize;
+                    let argname = leasename.arg_prefixed();
+                    // Note: we're not generating a panic message in the client to
+                    // save ROM space. If the user chases the line number into the
+                    // client stub source file the error should be clear.
+                    Some(quote! {
+                        if #argname.len() > #n {
+                            panic!();
+                        }
+                    })
+                });
+
+            // Define args struct.
+            let arg_struct_name =
+                quote::format_ident!("{}_{name}_ARGS", iface.name);
+            let arg_struct = {
+                let attrs = match op.encoding {
+                    syntax::Encoding::Zerocopy => {
+                        quote! {
+                            #[derive(zerocopy::AsBytes)]
+                            #[repr(C, packed)]
+                        }
+                    }
+                    syntax::Encoding::Ssmarshal => {
+                        quote! {
+                            #[derive(serde::Serialize)]
+                        }
+                    }
+                    syntax::Encoding::Hubpack => {
+                        quote! {
+                            #[derive(serde::Serialize, hubpack::SerializedSize)]
+                        }
+                    }
                 };
-                #encoding_prep
-            }
-        };
-
-        let send = {
-            let op_enum_name = iface_name.as_op_enum();
-            let buf = match op.encoding {
-                syntax::Encoding::Zerocopy => {
-                    quote! { zerocopy::AsBytes::as_bytes(&args) }
-                }
-                syntax::Encoding::Ssmarshal | syntax::Encoding::Hubpack => {
-                    quote! { &argsbuf[..arglen] }
+                let fields = op.args.iter().map(|(argname, arg)| {
+                    let ty = if arg.ty.is_bool() {
+                        quote! { u8 }
+                    } else {
+                        quote! { #arg }
+                    };
+                    quote! {
+                        #argname: #ty
+                    }
+                });
+                quote! {
+                    #[allow(non_camel_case_types)]
+                    #attrs
+                    struct #arg_struct_name {
+                        #( #fields ),*
+                    }
                 }
             };
-            let leases = op.leases.iter().map(|(leasename, lease)| {
+
+            // Determine required size of reply buffer.
+            fn size_expr(
+                encoding: &syntax::Encoding,
+                ty: &syntax::AttributedTy,
+            ) -> TokenStream {
+                match encoding {
+                    syntax::Encoding::Zerocopy
+                    | syntax::Encoding::Ssmarshal => {
+                        // Both these encodings guarantee that sizeof is big
+                        // enough.
+                        quote! { core::mem::size_of::<#ty>() }
+                    }
+                    syntax::Encoding::Hubpack => {
+                        quote! { <#ty as hubpack::SerializedSize>::MAX_SIZE }
+                    }
+                }
+            }
+            let reply_size = {
+                let size = match &op.reply {
+                    syntax::Reply::Simple(t) => size_expr(&op.encoding, t),
+                    syntax::Reply::Result { ok, err } => {
+                        let oksize = size_expr(&op.encoding, ok);
+                        let errsize = match err {
+                            syntax::Error::CLike(_)
+                            | syntax::Error::ServerDeath => {
+                                quote! { 0 }
+                            }
+                            syntax::Error::Complex(ty) => {
+                                quote! { <#ty as hubpack::SerializedSize>::MAX_SIZE; }
+                            }
+                        };
+                        quote! {
+                            let oksize = #oksize;
+                            let errsize = #errsize;
+                            if oksize > errsize { oksize } else { errsize }
+                        }
+                    }
+                };
+                quote! {
+                    const REPLY_SIZE: usize = {
+                        #size
+                    };
+                }
+            };
+
+            // Create instance of args struct from args.
+            let mk_arg_struct = {
+                let initializers = op.args.iter().map(|(argname, arg)| {
+                    let arg_argname = argname.arg_prefixed();
+                    if arg.ty.is_bool() {
+                        // Special case: we send booleans as non-zero u8, so that
+                        // we can use them in Zerocopy situations
+                        quote! { #argname: #arg_argname as u8 }
+                    } else {
+                        quote! { #argname: #arg_argname }
+                    }
+                });
+                let encoding_prep = match op.encoding {
+                    syntax::Encoding::Zerocopy => {
+                        // No further prep required.
+                        quote! {}
+                    }
+                    syntax::Encoding::Ssmarshal => {
+                        // Serialize the arguments.
+                        quote! {
+                            let mut argsbuf = [0; core::mem::size_of::<#arg_struct_name>()];
+                            let arglen = ssmarshal::serialize(&mut argsbuf, &args).unwrap_lite();
+                        }
+                    }
+                    syntax::Encoding::Hubpack => {
+                        // Serialize the arguments.
+                        quote! {
+                            let mut argsbuf = [0; <#arg_struct_name as hubpack::SerializedSize>::MAX_SIZE];
+                            let arglen = hubpack::serialize(&mut argsbuf, &args).unwrap_lite();
+                        }
+                    }
+                };
+                quote! {
+                    let args = #arg_struct_name {
+                        #( #initializers ),*
+                    };
+                    #encoding_prep
+                }
+            };
+
+            let send = {
+                let op_enum_name = iface_name.as_op_enum();
+                let buf = match op.encoding {
+                    syntax::Encoding::Zerocopy => {
+                        quote! { zerocopy::AsBytes::as_bytes(&args) }
+                    }
+                    syntax::Encoding::Ssmarshal | syntax::Encoding::Hubpack => {
+                        quote! { &argsbuf[..arglen] }
+                    }
+                };
+                let leases = op.leases.iter().map(|(leasename, lease)| {
                 let (ctor, asbytes) = match (lease.read, lease.write) {
                     (true, true) => ("read_write", "as_bytes_mut"),
                     (false, true) => ("write_only", "as_bytes_mut"),
@@ -314,225 +344,236 @@ fn client_stub_tokens(
                     userlib::Lease::#ctor(zerocopy::AsBytes::#asbytes(#argname))
                 }
             });
-            quote! {
-                let task = self.current_id.get();
-                let (rc, len) = sys_send(
-                    task,
-                    #op_enum_name::#name as u16,
-                    #buf,
-                    &mut reply,
-                    &[
-                        #( #leases ),*
-                    ],
-                );
-            }
-        };
-
-        let reply = {
-            let gen_decode = |t: &syntax::AttributedTy| match op.encoding {
-                syntax::Encoding::Zerocopy => {
-                    let reply_ty =
-                        quote::format_ident!("{iface_name}_{name}_REPLY");
-                    let repr_ty = t.repr_ty();
-                    quote! {
-                        let _len = len;
-                        #[derive(zerocopy::FromBytes, zerocopy::Unaligned)]
-                        #[repr(C, packed)]
-                        struct #reply_ty {
-                            value: #repr_ty,
-                        }
-                        let lv = zerocopy::LayoutVerified::<_, #reply_ty>::new_unaligned(&reply[..])
-                            .unwrap_lite();
-                        let v: #repr_ty = lv.value;
-                    }
+                quote! {
+                    let task = self.current_id.get();
+                    let (rc, len) = sys_send(
+                        task,
+                        #op_enum_name::#name as u16,
+                        #buf,
+                        &mut reply,
+                        &[
+                            #( #leases ),*
+                        ],
+                    );
                 }
-                syntax::Encoding::Ssmarshal => quote! {
-                    let (v, _): (#t, _) = ssmarshal::deserialize(&reply[..len]).unwrap_lite();
-                },
-                syntax::Encoding::Hubpack => quote! {
-                    let (v, _): (#t, _) = hubpack::deserialize(&reply[..len]).unwrap_lite();
-                },
             };
 
-            match &op.reply {
-                syntax::Reply::Simple(t) => {
-                    let decode = gen_decode(t);
-                    let ret = match &t.recv {
-                        syntax::RecvStrategy::FromBytes if t.ty.is_bool() => {
-                            quote! {return v != 0;}
-                        }
-                        syntax::RecvStrategy::FromBytes => quote! {return v;},
-                        syntax::RecvStrategy::From(_, None) => {
-                            quote! { return v.into(); }
-                        }
-                        syntax::RecvStrategy::From(_, Some(f)) => {
-                            quote! { return #f(v); }
-                        }
-                        syntax::RecvStrategy::FromPrimitive(p) => {
-                            let from_prim = quote::format_ident!("from_{p}");
-                            quote! { return <#t as userlib::FromPrimitive>::#from_prim(v).unwrap_lite(); }
-                        }
-                    };
-                    quote! {
-                        if rc != 0 { panic!(); }
-                        #decode
-                        #ret
-                    }
-                }
-                syntax::Reply::Result { ok, err } => {
-                    let decode = gen_decode(ok);
-                    let ret_ok = match &ok.recv {
-                        syntax::RecvStrategy::FromBytes if ok.ty.is_bool() => {
-                            quote! { return Ok(v != 0); }
-                        }
-                        syntax::RecvStrategy::FromBytes => {
-                            quote! { return Ok(v); }
-                        }
-                        syntax::RecvStrategy::From(_, None) => {
-                            quote! { return Ok(v.into()) }
-                        }
-                        syntax::RecvStrategy::From(_, Some(f)) => {
-                            quote! { return Ok(#f(v)) }
-                        }
-                        syntax::RecvStrategy::FromPrimitive(p) => {
-                            let from_prim = quote::format_ident!("from_{p}");
-                            quote! { return Ok(<#ok as userlib::FromPrimitive>::#from_prim(v).unwrap_lite()); }
-                        }
-                    };
-                    let ret_err = match err {
-                        syntax::Error::CLike(ty) => {
-                            let check_server_death = if op.idempotent {
-                                // Idempotent ops already checked for server death
-                                // above.
-                                quote! {}
-                            } else {
-                                quote! {
-                                    if let Some(g) = userlib::extract_new_generation(rc) {
-                                        self.current_id.set(userlib::TaskId::for_index_and_gen(task.index(), g));
-                                    }
-                                }
-                            };
-                            quote! {
-                                #check_server_death
-                                return Err(<#ty as core::convert::TryFrom<u32>>::try_from(rc)
-                                    .unwrap_lite());
+            let reply = {
+                let gen_decode = |t: &syntax::AttributedTy| match op.encoding {
+                    syntax::Encoding::Zerocopy => {
+                        let reply_ty =
+                            quote::format_ident!("{iface_name}_{name}_REPLY");
+                        let repr_ty = t.repr_ty();
+                        quote! {
+                            let _len = len;
+                            #[derive(zerocopy::FromBytes, zerocopy::Unaligned)]
+                            #[repr(C, packed)]
+                            struct #reply_ty {
+                                value: #repr_ty,
                             }
+                            let lv = zerocopy::LayoutVerified::<_, #reply_ty>::new_unaligned(&reply[..])
+                                .unwrap_lite();
+                            let v: #repr_ty = lv.value;
                         }
-                        syntax::Error::Complex(ty) => {
-                            match op.encoding {
-                                syntax::Encoding::Hubpack => {
-                                    let check_server_death = if op.idempotent {
-                                        // Idempotent ops already checked for server death
-                                        // above.
-                                        quote! {}
-                                    } else {
-                                        quote! {
-                                            if let Some(g) = userlib::extract_new_generation(rc) {
-                                                self.current_id.set(userlib::TaskId::for_index_and_gen(task.index(), g));
-                                                return Err(#ty::from(idol_runtime::ServerDeath));
-                                            }
-                                        }
-                                    };
+                    }
+                    syntax::Encoding::Ssmarshal => quote! {
+                        let (v, _): (#t, _) = ssmarshal::deserialize(&reply[..len]).unwrap_lite();
+                    },
+                    syntax::Encoding::Hubpack => quote! {
+                        let (v, _): (#t, _) = hubpack::deserialize(&reply[..len]).unwrap_lite();
+                    },
+                };
+
+                match &op.reply {
+                    syntax::Reply::Simple(t) => {
+                        let decode = gen_decode(t);
+                        let ret = match &t.recv {
+                            syntax::RecvStrategy::FromBytes
+                                if t.ty.is_bool() =>
+                            {
+                                quote! {return v != 0;}
+                            }
+                            syntax::RecvStrategy::FromBytes => {
+                                quote! {return v;}
+                            }
+                            syntax::RecvStrategy::From(_, None) => {
+                                quote! { return v.into(); }
+                            }
+                            syntax::RecvStrategy::From(_, Some(f)) => {
+                                quote! { return #f(v); }
+                            }
+                            syntax::RecvStrategy::FromPrimitive(p) => {
+                                let from_prim =
+                                    quote::format_ident!("from_{p}");
+                                quote! { return <#t as userlib::FromPrimitive>::#from_prim(v).unwrap_lite(); }
+                            }
+                        };
+                        quote! {
+                            if rc != 0 { panic!(); }
+                            #decode
+                            #ret
+                        }
+                    }
+                    syntax::Reply::Result { ok, err } => {
+                        let decode = gen_decode(ok);
+                        let ret_ok = match &ok.recv {
+                            syntax::RecvStrategy::FromBytes
+                                if ok.ty.is_bool() =>
+                            {
+                                quote! { return Ok(v != 0); }
+                            }
+                            syntax::RecvStrategy::FromBytes => {
+                                quote! { return Ok(v); }
+                            }
+                            syntax::RecvStrategy::From(_, None) => {
+                                quote! { return Ok(v.into()) }
+                            }
+                            syntax::RecvStrategy::From(_, Some(f)) => {
+                                quote! { return Ok(#f(v)) }
+                            }
+                            syntax::RecvStrategy::FromPrimitive(p) => {
+                                let from_prim =
+                                    quote::format_ident!("from_{p}");
+                                quote! { return Ok(<#ok as userlib::FromPrimitive>::#from_prim(v).unwrap_lite()); }
+                            }
+                        };
+                        let ret_err = match err {
+                            syntax::Error::CLike(ty) => {
+                                let check_server_death = if op.idempotent {
+                                    // Idempotent ops already checked for server death
+                                    // above.
+                                    quote! {}
+                                } else {
                                     quote! {
-                                        #check_server_death
-                                        let (v, _): (#ty, _) = hubpack::deserialize(&reply[..len]).unwrap_lite();
-                                        return Err(v);
+                                        if let Some(g) = userlib::extract_new_generation(rc) {
+                                            self.current_id.set(userlib::TaskId::for_index_and_gen(task.index(), g));
+                                        }
                                     }
+                                };
+                                quote! {
+                                    #check_server_death
+                                    return Err(<#ty as core::convert::TryFrom<u32>>::try_from(rc)
+                                        .unwrap_lite());
                                 }
-                                e => {
-                                    panic!(
+                            }
+                            syntax::Error::Complex(ty) => {
+                                match op.encoding {
+                                    syntax::Encoding::Hubpack => {
+                                        let check_server_death = if op
+                                            .idempotent
+                                        {
+                                            // Idempotent ops already checked for server death
+                                            // above.
+                                            quote! {}
+                                        } else {
+                                            quote! {
+                                                if let Some(g) = userlib::extract_new_generation(rc) {
+                                                    self.current_id.set(userlib::TaskId::for_index_and_gen(task.index(), g));
+                                                    return Err(#ty::from(idol_runtime::ServerDeath));
+                                                }
+                                            }
+                                        };
+                                        quote! {
+                                            #check_server_death
+                                            let (v, _): (#ty, _) = hubpack::deserialize(&reply[..len]).unwrap_lite();
+                                            return Err(v);
+                                        }
+                                    }
+                                    e => {
+                                        panic!(
                                     "Complex error types not supported for \
                                     {e:?} encoding, sorry"
                                 );
+                                    }
                                 }
                             }
-                        }
-                        syntax::Error::ServerDeath => {
-                            assert!(!op.idempotent, "idempotent operations should not indicate server death");
-                            quote! {
-                                if let Some(g) = userlib::extract_new_generation(rc) {
-                                    self.current_id.set(userlib::TaskId::for_index_and_gen(task.index(), g));
-                                    return Err(idol_runtime::ServerDeath);
-                                } else {
-                                    panic!()
+                            syntax::Error::ServerDeath => {
+                                assert!(!op.idempotent, "idempotent operations should not indicate server death");
+                                quote! {
+                                    if let Some(g) = userlib::extract_new_generation(rc) {
+                                        self.current_id.set(userlib::TaskId::for_index_and_gen(task.index(), g));
+                                        return Err(idol_runtime::ServerDeath);
+                                    } else {
+                                        panic!()
+                                    }
                                 }
                             }
-                        }
-                    };
-                    quote! {
-                        if rc == 0 {
-                            #decode
-                            #ret_ok
-                        } else {
-                            #ret_err
+                        };
+                        quote! {
+                            if rc == 0 {
+                                #decode
+                                #ret_ok
+                            } else {
+                                #ret_err
+                            }
                         }
                     }
                 }
-            }
-        };
+            };
 
-        let body = if op.idempotent {
-            quote! {
-                loop {
-                    #send
+            let body = if op.idempotent {
+                quote! {
+                    loop {
+                        #send
 
-                    // If the operation is idempotent but failed due to server death, retry.
-                    if let Some(g) = userlib::extract_new_generation(rc) {
-                        self.current_id.set(userlib::TaskId::for_index_and_gen(task.index(), g));
-                        continue;
+                        // If the operation is idempotent but failed due to server death, retry.
+                        if let Some(g) = userlib::extract_new_generation(rc) {
+                            self.current_id.set(userlib::TaskId::for_index_and_gen(task.index(), g));
+                            continue;
+                        }
+
+                        #reply
                     }
-
+                }
+            } else {
+                quote! {
+                    #send
                     #reply
                 }
+            };
+            ops.push(quote! {
+                #[doc = #operation]
+                #idempotent
+                pub fn #name(&self, #(#args,)* #(#leases,)*) -> #reply_ty {
+                    #argmap
+                    #(#lease_validators)*
+                    #arg_struct
+                    #reply_size
+                    let mut reply = [0u8; REPLY_SIZE];
+                    #mk_arg_struct
+                    #body
+                }
+            })
+        }
+        Ok(quote! {
+            #[allow(unused_imports)]
+            use userlib::UnwrapLite;
+
+            #[derive(Clone, Debug)]
+            pub struct #iface_name {
+                current_id: core::cell::Cell<userlib::TaskId>,
             }
-        } else {
-            quote! {
-                #send
-                #reply
+
+            #[automatically_derived]
+            impl From<userlib::TaskId> for #iface_name {
+                fn from(x: userlib::TaskId) -> Self {
+                    Self { current_id: core::cell::Cell::new(x) }
+                }
             }
-        };
-        ops.push(quote! {
-            #[doc = #operation]
-            #idempotent
-            pub fn #name(&self, #(#args,)* #(#leases,)*) -> #reply_ty {
-                #argmap
-                #(#lease_validators)*
-                #arg_struct
-                #reply_size
-                let mut reply = [0u8; REPLY_SIZE];
-                #mk_arg_struct
-                #body
+
+            #[allow(clippy::let_unit_value,
+                    clippy::collapsible_else_if,
+                    clippy::needless_return,
+                    clippy::unused_unit,
+                    // code generation may include unnecessary braces and/or parens
+                    // if it doesn't know whether a block contains one or more
+                    // expressions.
+                    unused_braces,
+                    unused_parens)]
+            #[automatically_derived]
+            impl #iface_name {
+                #(#ops)*
             }
         })
     }
-    Ok(quote! {
-        #[allow(unused_imports)]
-        use userlib::UnwrapLite;
-
-        #[derive(Clone, Debug)]
-        pub struct #iface_name {
-            current_id: core::cell::Cell<userlib::TaskId>,
-        }
-
-        #[automatically_derived]
-        impl From<userlib::TaskId> for #iface_name {
-            fn from(x: userlib::TaskId) -> Self {
-                Self { current_id: core::cell::Cell::new(x) }
-            }
-        }
-
-        #[allow(clippy::let_unit_value,
-                clippy::collapsible_else_if,
-                clippy::needless_return,
-                clippy::unused_unit,
-                // code generation may include unnecessary braces and/or parens
-                // if it doesn't know whether a block contains one or more
-                // expressions.
-                unused_braces,
-                unused_parens)]
-        #[automatically_derived]
-        impl #iface_name {
-            #(#ops)*
-        }
-    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,30 @@ pub(crate) mod serde_helpers;
 pub mod server;
 pub mod syntax;
 
+/// Settings that configure how client and server stubs are generated.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[must_use]
+pub struct Generator {
+    pub(crate) fmt: bool,
+}
+
+impl Generator {
+    pub fn new() -> Self {
+        Self { fmt: true }
+    }
+
+    /// If `true`, generated code will be formatted with `prettyplease`.
+    pub fn with_formatting(self, fmt: bool) -> Self {
+        Self { fmt, ..self }
+    }
+}
+
+impl Default for Generator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{common, syntax};
+use super::{common, syntax, Generator};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::BTreeMap;
@@ -20,7 +20,7 @@ pub fn build_server_support(
     stub_name: &str,
     style: ServerStyle,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    build_restricted_server_support(source, stub_name, style, &BTreeMap::new())
+    Generator::default().build_server_support(source, stub_name, style)
 }
 
 pub fn build_restricted_server_support(
@@ -29,598 +29,633 @@ pub fn build_restricted_server_support(
     style: ServerStyle,
     allowed_callers: &BTreeMap<String, Vec<usize>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    let mut stub_file = File::create(out.join(stub_name)).unwrap();
-
-    let text = std::fs::read_to_string(source)?;
-    let iface: syntax::Interface = ron::de::from_str(&text)?;
-    let mut tokens =
-        generate_restricted_server_support(&iface, style, allowed_callers)?;
-
-    tokens.extend(generate_server_section(&iface, &text));
-    let formatted = common::fmt_tokens(tokens)?;
-    write!(stub_file, "{formatted}")?;
-    println!("cargo:rerun-if-changed={}", source);
-    Ok(())
+    Generator::default().build_restricted_server_support(
+        source,
+        stub_name,
+        style,
+        allowed_callers,
+    )
 }
 
-// `Name` is only mutable as it contains `OnceCell`s, but they don't effect its
-// `Hash`, `PartialEq`, `Eq`, `Ord`, or `PartialOrd` implementations. So, it can
-// safely be used as a map key.
-#[allow(clippy::mutable_key_type)]
-pub fn generate_restricted_server_support(
-    iface: &syntax::Interface,
-    style: ServerStyle,
-    allowed_callers: &BTreeMap<String, Vec<usize>>,
-) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
-    let mut tokens = quote! {
-        #[allow(unused_imports)]
-        use userlib::UnwrapLite;
-    };
+impl Generator {
+    pub fn build_server_support(
+        &self,
+        source: &str,
+        stub_name: &str,
+        style: ServerStyle,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.build_restricted_server_support(
+            source,
+            stub_name,
+            style,
+            &BTreeMap::new(),
+        )
+    }
 
-    tokens.extend(generate_server_constants(iface));
-    tokens.extend(generate_server_conversions(iface));
-    tokens.extend(common::generate_op_enum(iface));
-    tokens.extend(generate_server_op_impl(iface));
+    pub fn build_restricted_server_support(
+        &self,
+        source: &str,
+        stub_name: &str,
+        style: ServerStyle,
+        allowed_callers: &BTreeMap<String, Vec<usize>>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        let mut stub_file = File::create(out.join(stub_name)).unwrap();
 
-    tokens.extend(match style {
-        ServerStyle::InOrder => {
-            generate_server_in_order_trait(iface, allowed_callers)?
+        let text = std::fs::read_to_string(source)?;
+        let iface: syntax::Interface = ron::de::from_str(&text)?;
+        let mut tokens = self.generate_restricted_server_support(
+            &iface,
+            style,
+            allowed_callers,
+        )?;
+
+        tokens.extend(generate_server_section(&iface, &text));
+        if self.fmt {
+            let formatted = common::fmt_tokens(tokens)?;
+            write!(stub_file, "{formatted}")?;
+        } else {
+            write!(stub_file, "{tokens}")?;
         }
-    });
 
-    Ok(tokens)
-}
+        println!("cargo:rerun-if-changed={}", source);
+        Ok(())
+    }
 
-pub fn generate_server_constants(iface: &syntax::Interface) -> TokenStream {
-    // Generate message sizing constants for each message.
-    let mut msgsize_names = Vec::with_capacity(iface.ops.len());
-    let consts = iface.ops.iter().map(|(name, op)| {
-        let msg_size = {
-            let const_name = format_ident!("{}_MSG_SIZE", name.uppercase());
-            let val = match op.encoding {
-                // Zerocopy moves fields as a packed struct, so the sum of input
-                // type sizes is sufficient to fit the message.
-                syntax::Encoding::Zerocopy => {
-                    let vals = op.args.values().map(|arg| {
-                        quote! {
-                            + core::mem::size_of::<#arg>()
-                        }
-                    });
-                    quote! { 0 #( #vals )* }
-                }
-
-                // ssmarshal guarantees that the serialized size will be no longer
-                // than the size of the input struct. Note that this may be larger
-                // than the sum of struct members!
-                syntax::Encoding::Ssmarshal => {
-                    let args = format_ident!("{}_{name}_ARGS", iface.name);
-                    quote! { core::mem::size_of::<#args>() }
-                }
-
-                // hubpack's SerializedSize traits defines a `MAX_SIZE` associated
-                // constant
-                syntax::Encoding::Hubpack => {
-                    let args = format_ident!("{}_{name}_ARGS", iface.name);
-                    quote! { <#args as hubpack::SerializedSize>::MAX_SIZE }
-                }
-            };
-
-            let tokens = quote! {
-                pub const #const_name: usize = #val;
-            };
-            msgsize_names.push(const_name);
-            tokens
+    pub fn generate_restricted_server_support(
+        &self,
+        iface: &syntax::Interface,
+        style: ServerStyle,
+        allowed_callers: &BTreeMap<String, Vec<usize>>,
+    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        let mut tokens = quote! {
+            #[allow(unused_imports)]
+            use userlib::UnwrapLite;
         };
-        let reply_size = {
-            let const_name = name.as_reply_size();
-            let val = match &op.reply {
-                syntax::Reply::Result { ok, .. } => {
-                    // This strategy only uses bytes for the OK side of the type,
-                    // and only sends one type, so:
-                    match op.encoding {
+
+        tokens.extend(self.generate_server_constants(iface));
+        tokens.extend(self.generate_server_conversions(iface));
+        tokens.extend(common::generate_op_enum(iface));
+        tokens.extend(self.generate_server_op_impl(iface));
+
+        tokens.extend(match style {
+            ServerStyle::InOrder => {
+                self.generate_server_in_order_trait(iface, allowed_callers)?
+            }
+        });
+
+        Ok(tokens)
+    }
+
+
+    pub fn generate_server_constants(&self, iface: &syntax::Interface) -> TokenStream {
+        // Generate message sizing constants for each message.
+        let mut msgsize_names = Vec::with_capacity(iface.ops.len());
+        let consts = iface.ops.iter().map(|(name, op)| {
+            let msg_size = {
+                let const_name = format_ident!("{}_MSG_SIZE", name.uppercase());
+                let val = match op.encoding {
+                    // Zerocopy moves fields as a packed struct, so the sum of input
+                    // type sizes is sufficient to fit the message.
+                    syntax::Encoding::Zerocopy => {
+                        let vals = op.args.values().map(|arg| {
+                            quote! {
+                                + core::mem::size_of::<#arg>()
+                            }
+                        });
+                        quote! { 0 #( #vals )* }
+                    }
+
+                    // ssmarshal guarantees that the serialized size will be no longer
+                    // than the size of the input struct. Note that this may be larger
+                    // than the sum of struct members!
+                    syntax::Encoding::Ssmarshal => {
+                        let args = format_ident!("{}_{name}_ARGS", iface.name);
+                        quote! { core::mem::size_of::<#args>() }
+                    }
+
+                    // hubpack's SerializedSize traits defines a `MAX_SIZE` associated
+                    // constant
+                    syntax::Encoding::Hubpack => {
+                        let args = format_ident!("{}_{name}_ARGS", iface.name);
+                        quote! { <#args as hubpack::SerializedSize>::MAX_SIZE }
+                    }
+                };
+
+                let tokens = quote! {
+                    pub const #const_name: usize = #val;
+                };
+                msgsize_names.push(const_name);
+                tokens
+            };
+            let reply_size = {
+                let const_name = name.as_reply_size();
+                let val = match &op.reply {
+                    syntax::Reply::Result { ok, .. } => {
+                        // This strategy only uses bytes for the OK side of the type,
+                        // and only sends one type, so:
+                        match op.encoding {
+                            syntax::Encoding::Zerocopy
+                            | syntax::Encoding::Ssmarshal => quote! {
+                            core::mem::size_of::<#ok>()
+                            },
+                            syntax::Encoding::Hubpack => quote! {
+                                <#ok as hubpack::SerializedSize>::MAX_SIZE
+                            },
+                        }
+                    }
+                    syntax::Reply::Simple(t) => match op.encoding {
                         syntax::Encoding::Zerocopy
                         | syntax::Encoding::Ssmarshal => quote! {
-                           core::mem::size_of::<#ok>()
+                            core::mem::size_of::<#t>()
                         },
                         syntax::Encoding::Hubpack => quote! {
-                            <#ok as hubpack::SerializedSize>::MAX_SIZE
+                            <#t as hubpack::SerializedSize>::MAX_SIZE
                         },
-                    }
+                    },
+                };
+                quote! {
+                    pub const #const_name: usize = #val;
                 }
-                syntax::Reply::Simple(t) => match op.encoding {
-                    syntax::Encoding::Zerocopy
-                    | syntax::Encoding::Ssmarshal => quote! {
-                        core::mem::size_of::<#t>()
-                    },
-                    syntax::Encoding::Hubpack => quote! {
-                        <#t as hubpack::SerializedSize>::MAX_SIZE
-                    },
-                },
             };
             quote! {
-                pub const #const_name: usize = #val;
+                #msg_size
+                #reply_size
             }
-        };
+        });
+
         quote! {
-            #msg_size
-            #reply_size
-        }
-    });
+            #( #consts )*
 
-    quote! {
-        #( #consts )*
-
-        // `max_incoming_size` may compare `max < 0`, which we want to ignore
-        #[allow(clippy::absurd_extreme_comparisons)]
-        const fn max_incoming_size() -> usize {
-            let mut max = 0;
-            #(
-                if max < #msgsize_names {
-                    max = #msgsize_names;
-                }
-            )*
-            max
-        }
-        pub const INCOMING_SIZE: usize = max_incoming_size();
-    }
-}
-
-pub fn generate_server_conversions(iface: &syntax::Interface) -> TokenStream {
-    let conversions = iface.ops.iter().map(|(name, op)| {
-        // Define args struct.
-            let attrs = match op.encoding {
-                syntax::Encoding::Zerocopy => quote! {
-                    #[repr(C, packed)]
-                    #[derive(Copy, Clone, zerocopy::FromBytes, zerocopy::Unaligned)]
-                },
-                syntax::Encoding::Ssmarshal => quote! {
-                    #[derive(Copy, Clone, serde::Deserialize)]
-                },
-                syntax::Encoding::Hubpack => quote! {
-                    #[derive(Copy, Clone, serde::Deserialize, hubpack::SerializedSize)]
-                },
-            };
-            if !matches!(op.encoding, syntax::Encoding::Zerocopy) {
-                // The recv strategy thing only really makes sense for the Zerocopy
-                // encoding. In particular, generated clients for the other encoding
-                // won't use it.
-                for (argname, arg) in &op.args {
-                    if !matches!(arg.recv, syntax::RecvStrategy::FromBytes) {
-                        panic!("operation {name} argument {argname} uses a recv strategy, \
-                            but this won't work with Ssmarshal/Hubpack encoding (remove it)");
+            // `max_incoming_size` may compare `max < 0`, which we want to ignore
+            #[allow(clippy::absurd_extreme_comparisons)]
+            const fn max_incoming_size() -> usize {
+                let mut max = 0;
+                #(
+                    if max < #msgsize_names {
+                        max = #msgsize_names;
                     }
-                }
+                )*
+                max
             }
-            let mut need_args_impl = false;
-            let args = op.args.iter().map(|(argname, arg)| {
-                match &arg.recv {
-                    syntax::RecvStrategy::FromBytes if arg.ty.is_bool() => {
-                        // Special-case handling to send bools using a Zerocopy
-                        // encoding strategy, for efficiency.
-                        let ident =argname.raw_prefixed();
-                        need_args_impl = true;
-                        quote! {
-                            pub #ident: u8
+            pub const INCOMING_SIZE: usize = max_incoming_size();
+        }
+    }
+
+    pub fn generate_server_conversions(&self, iface: &syntax::Interface) -> TokenStream {
+        let conversions = iface.ops.iter().map(|(name, op)| {
+            // Define args struct.
+                let attrs = match op.encoding {
+                    syntax::Encoding::Zerocopy => quote! {
+                        #[repr(C, packed)]
+                        #[derive(Copy, Clone, zerocopy::FromBytes, zerocopy::Unaligned)]
+                    },
+                    syntax::Encoding::Ssmarshal => quote! {
+                        #[derive(Copy, Clone, serde::Deserialize)]
+                    },
+                    syntax::Encoding::Hubpack => quote! {
+                        #[derive(Copy, Clone, serde::Deserialize, hubpack::SerializedSize)]
+                    },
+                };
+                if !matches!(op.encoding, syntax::Encoding::Zerocopy) {
+                    // The recv strategy thing only really makes sense for the Zerocopy
+                    // encoding. In particular, generated clients for the other encoding
+                    // won't use it.
+                    for (argname, arg) in &op.args {
+                        if !matches!(arg.recv, syntax::RecvStrategy::FromBytes) {
+                            panic!("operation {name} argument {argname} uses a recv strategy, \
+                                but this won't work with Ssmarshal/Hubpack encoding (remove it)");
                         }
                     }
-                    syntax::RecvStrategy::FromBytes => {
-                        let ty = &arg.ty;
-                        quote! {pub #argname: #ty }
+                }
+                let mut need_args_impl = false;
+                let args = op.args.iter().map(|(argname, arg)| {
+                    match &arg.recv {
+                        syntax::RecvStrategy::FromBytes if arg.ty.is_bool() => {
+                            // Special-case handling to send bools using a Zerocopy
+                            // encoding strategy, for efficiency.
+                            let ident =argname.raw_prefixed();
+                            need_args_impl = true;
+                            quote! {
+                                pub #ident: u8
+                            }
+                        }
+                        syntax::RecvStrategy::FromBytes => {
+                            let ty = &arg.ty;
+                            quote! {pub #argname: #ty }
+                        }
+                        syntax::RecvStrategy::FromPrimitive(ty)
+                        | syntax::RecvStrategy::From(ty, _) => {
+                            need_args_impl = true;
+                            let ident = argname.raw_prefixed();
+                            quote! {
+                                pub #ident: #ty
+                            }
+                        }
                     }
-                    syntax::RecvStrategy::FromPrimitive(ty)
-                    | syntax::RecvStrategy::From(ty, _) => {
-                        need_args_impl = true;
-                        let ident = argname.raw_prefixed();
+                });
+                let struct_name = format_ident!("{}_{name}_ARGS", iface.name);
+                let struct_def = quote! {
+                    #attrs
+                    #[allow(non_camel_case_types)]
+                    pub struct #struct_name {
+                        #( #args ),*
+                    }
+                };
+                let args_impl = if need_args_impl {
+                    let args_fns = op.args.iter().map(|(argname, arg)| {
+                        match &arg.recv {
+                            syntax::RecvStrategy::FromPrimitive(ty) => {
+                                let arg_ty = &arg.ty;
+                                let raw_argname = argname.raw_prefixed();
+                                let from_ty = format_ident!("from_{ty}");
+                                quote! {
+                                    pub fn #argname(&self) -> Option<#arg_ty> {
+                                        userlib::FromPrimitive::#from_ty(self.#raw_argname)
+                                    }
+                                }
+                            }
+                            syntax::RecvStrategy::FromBytes if arg.ty.is_bool() => {
+                                // The only FromBytes type which also needs a decoder
+                                // function is a `bool` encoded as a single `u8`
+                                let raw_argname = argname.raw_prefixed();
+                                quote! {
+                                    pub fn #argname(&self) -> bool {
+                                        self.#raw_argname != 0
+                                    }
+                                }
+                            }
+                            _ => quote! {}
+                        }
+                    });
+                    quote! {
+                        impl #struct_name {
+                            #( #args_fns )*
+                        }
+                    }
+                } else {
+                    quote! {}
+                };
+
+                let read_fn = {
+                    let read_fn = format_ident!("read_{}_msg", name);
+                    match op.encoding {
+                        syntax::Encoding::Zerocopy => quote! {
+                            pub fn #read_fn(bytes: &[u8]) -> Option<&#struct_name> {
+                                Some(zerocopy::LayoutVerified::<_, #struct_name>::new_unaligned(bytes)?
+                                    .into_ref())
+                            }
+                        },
+                        syntax::Encoding::Ssmarshal => quote! {
+                            pub fn #read_fn(bytes: &[u8]) -> Option<#struct_name> {
+                                ssmarshal::deserialize(bytes).ok().map(|(x, _)| x)
+                            }
+                        },
+                        syntax::Encoding::Hubpack => quote! {
+                            pub fn #read_fn(bytes: &[u8]) -> Option<#struct_name> {
+                                hubpack::deserialize(bytes).ok().map(|(x, _)| x)
+                            }
+                        },
+                    }
+                };
+
+                // The DWARF generated for types is load-bearing in that Humility
+                // potentially needs them to be able to form arguments to Idol calls
+                // and to make sense of the reply.  But if an Idol server is declared
+                // without a consuming Idol client, any synthetic reply type won't be
+                // generated.  To force any synthetic reply type definition to be
+                // generated, we create a meaningless static (that itself will be
+                // optimized away), which has the side-effect of getting the type that
+                // we need in the binary (but without changing the generated text or
+                // data).
+                let mut reply_ty_def = quote! {};
+
+                if let syntax::Reply::Result { ok, err: _ } = &op.reply {
+                    if let syntax::Encoding::Zerocopy = op.encoding {
+                        let reply_ty = format_ident!("{}_{name}_REPLY", iface.name);
+                        let static_name = format_ident!(
+                            "{}_{}_REPLY",
+                            iface.name.uppercase(),
+                            name.uppercase(),
+                        );
+                        reply_ty_def = quote! {
+                            #[repr(C, packed)]
+                            struct #reply_ty {
+                                value: #ok,
+                            }
+                            #[allow(dead_code)]
+                            static #static_name: Option<&#reply_ty> = None;
+                        }
+                    }
+                };
+
+                quote! {
+                    #struct_def
+                    #args_impl
+                    #read_fn
+                    #reply_ty_def
+                }
+            });
+        quote! {
+            #( #conversions )*
+        }
+    }
+
+    pub fn generate_server_op_impl(&self, iface: &syntax::Interface) -> TokenStream {
+        let op_enum = iface.name.as_op_enum();
+        let max_reply_size_cases = iface.ops.keys().map(|opname| {
+            let reply_size = opname.as_reply_size();
+            quote! {
+                Self::#opname => #reply_size,
+            }
+        });
+        let required_leases_cases = iface.ops.iter().map(|(opname, op)| {
+            let leases = op.leases.len();
+            quote! {
+                Self::#opname => #leases,
+            }
+        });
+        quote! {
+            #[automatically_derived]
+            impl idol_runtime::ServerOp for #op_enum {
+                fn max_reply_size(self) -> usize {
+                    match self {
+                        #( #max_reply_size_cases )*
+                    }
+                }
+
+                fn required_lease_count(self) -> usize {
+                    match self {
+                        #( #required_leases_cases )*
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn generate_server_in_order_trait(
+        &self,
+        iface: &syntax::Interface,
+        allowed_callers: &BTreeMap<String, Vec<usize>>,
+    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+           // Ensure any operations listed in `allowed_callers` actually exist for this
+        // server.
+        for opname in allowed_callers.keys() {
+            if !iface.ops.contains_key(opname.as_str()) {
+                return Err(Box::from(format!(
+                    "allowed_callers operation `{}` does not exist for this server",
+                    opname
+                )));
+            }
+        }
+
+        let iface_name = &iface.name;
+        let trt = format_ident!("InOrder{iface_name}Impl");
+        let trait_def = generate_trait_def(iface, &trt);
+
+        let enum_name = iface.name.as_op_enum();
+        let op_cases = iface.ops.iter().map(|(opname, op)| {
+            let check_allowed = if let Some(allowed_callers) = allowed_callers.get(opname.as_str()) {
+                // With our current optimization settings and rustc/llvm version,
+                // the compiler generates better code for raw `if` checks than it
+                // does for the more general `[T;N].contains(&T)`. We'll do a bit of
+                // manual optimization here; if `allowed_callers` is less than 4
+                // (which we expect it to be basically always), we'll generate a
+                // suitable `if`. For longer allowed_callers lists, we'll fall back
+                // to `[T;N].contains(&T)`, which produces a loop.
+                let cond = if allowed_callers.len() < 4 {
+                    quote! {
+                        {
+                            let sender = rm.sender.index();
+                            #( sender != #allowed_callers )&&*
+                        }
+                    }
+                } else {
+                    quote! {
+                        ![#( #allowed_callers ),*].contains(&rm.sender.index())
+                    }
+                };
+                quote! {
+                    // Clippy doesn't like when the block generated by the len < 4
+                    // case is in the if condition, so assign it to a variable.
+                    let disallowed = #cond;
+                    if disallowed {
+                        return Err(idol_runtime::RequestError::Fail(
+                            idol_runtime::ClientError::AccessViolation
+                        ));
+                    }
+                }
+            } else {
+                quote!{}
+            };
+            let read = {
+                let arg_var = if op.args.is_empty() {
+                    quote! { _ }
+                } else {
+                    quote! { args }
+                };
+                let readfn = format_ident!("read_{opname}_msg");
+                quote! {
+                    let #arg_var = #readfn(incoming).ok_or_else(|| {
+                        idol_runtime::ClientError::BadMessageContents.fail()
+                    })?;
+                }
+            };
+            let args = op.args.iter().map(|(argname, arg)| {
+                match &arg.recv {
+                    syntax::RecvStrategy::FromBytes => {
+                        let thingy = if arg.ty.is_bool() {
+                            quote! { #argname() }
+                        } else {
+                            quote! { #argname }
+                        };
                         quote! {
-                            pub #ident: #ty
+                            args.#thingy,
+                        }
+                    },
+                    syntax::RecvStrategy::From(_, None) => {
+                        let name = argname.raw_prefixed();
+                        quote! {
+                            args.#name.into(),
+                        }
+                    }
+                    syntax::RecvStrategy::From(_, Some(f)) => {
+                        let name = argname.raw_prefixed();
+                        quote! {
+                            #f(args.#name),
+                        }
+                    }
+                    syntax::RecvStrategy::FromPrimitive(_) => {
+                        quote! {
+                            args.#argname().ok_or_else(|| {
+                                idol_runtime::ClientError::BadMessageContents.fail()
+                            })?,
                         }
                     }
                 }
             });
-            let struct_name = format_ident!("{}_{name}_ARGS", iface.name);
-            let struct_def = quote! {
-                #attrs
-                #[allow(non_camel_case_types)]
-                pub struct #struct_name {
-                    #( #args ),*
-                }
-            };
-            let args_impl = if need_args_impl {
-                let args_fns = op.args.iter().map(|(argname, arg)| {
-                    match &arg.recv {
-                        syntax::RecvStrategy::FromPrimitive(ty) => {
-                            let arg_ty = &arg.ty;
-                            let raw_argname = argname.raw_prefixed();
-                            let from_ty = format_ident!("from_{ty}");
-                            quote! {
-                                pub fn #argname(&self) -> Option<#arg_ty> {
-                                    userlib::FromPrimitive::#from_ty(self.#raw_argname)
-                                }
-                            }
-                        }
-                        syntax::RecvStrategy::FromBytes if arg.ty.is_bool() => {
-                            // The only FromBytes type which also needs a decoder
-                            // function is a `bool` encoded as a single `u8`
-                            let raw_argname = argname.raw_prefixed();
-                            quote! {
-                                pub fn #argname(&self) -> bool {
-                                    self.#raw_argname != 0
-                                }
-                            }
-                        }
-                        _ => quote! {}
-                    }
-                });
-                quote! {
-                    impl #struct_name {
-                        #( #args_fns )*
-                    }
-                }
-            } else {
-                quote! {}
-            };
-
-            let read_fn = {
-                let read_fn = format_ident!("read_{}_msg", name);
-                match op.encoding {
-                    syntax::Encoding::Zerocopy => quote! {
-                        pub fn #read_fn(bytes: &[u8]) -> Option<&#struct_name> {
-                            Some(zerocopy::LayoutVerified::<_, #struct_name>::new_unaligned(bytes)?
-                                .into_ref())
-                        }
-                    },
-                    syntax::Encoding::Ssmarshal => quote! {
-                        pub fn #read_fn(bytes: &[u8]) -> Option<#struct_name> {
-                            ssmarshal::deserialize(bytes).ok().map(|(x, _)| x)
-                        }
-                    },
-                    syntax::Encoding::Hubpack => quote! {
-                        pub fn #read_fn(bytes: &[u8]) -> Option<#struct_name> {
-                            hubpack::deserialize(bytes).ok().map(|(x, _)| x)
-                        }
-                    },
-                }
-            };
-
-            // The DWARF generated for types is load-bearing in that Humility
-            // potentially needs them to be able to form arguments to Idol calls
-            // and to make sense of the reply.  But if an Idol server is declared
-            // without a consuming Idol client, any synthetic reply type won't be
-            // generated.  To force any synthetic reply type definition to be
-            // generated, we create a meaningless static (that itself will be
-            // optimized away), which has the side-effect of getting the type that
-            // we need in the binary (but without changing the generated text or
-            // data).
-            let mut reply_ty_def = quote! {};
-
-            if let syntax::Reply::Result { ok, err: _ } = &op.reply {
-                if let syntax::Encoding::Zerocopy = op.encoding {
-                    let reply_ty = format_ident!("{}_{name}_REPLY", iface.name);
-                    let static_name = format_ident!(
-                        "{}_{}_REPLY",
-                        iface.name.uppercase(),
-                        name.uppercase(),
-                    );
-                    reply_ty_def = quote! {
-                        #[repr(C, packed)]
-                        struct #reply_ty {
-                            value: #ok,
-                        }
-                        #[allow(dead_code)]
-                        static #static_name: Option<&#reply_ty> = None;
-                    }
-                }
-            };
-
-            quote! {
-                #struct_def
-                #args_impl
-                #read_fn
-                #reply_ty_def
-            }
-        });
-    quote! {
-        #( #conversions )*
-    }
-}
-
-pub fn generate_server_op_impl(iface: &syntax::Interface) -> TokenStream {
-    let op_enum = iface.name.as_op_enum();
-    let max_reply_size_cases = iface.ops.keys().map(|opname| {
-        let reply_size = opname.as_reply_size();
-        quote! {
-            Self::#opname => #reply_size,
-        }
-    });
-    let required_leases_cases = iface.ops.iter().map(|(opname, op)| {
-        let leases = op.leases.len();
-        quote! {
-            Self::#opname => #leases,
-        }
-    });
-    quote! {
-        #[automatically_derived]
-        impl idol_runtime::ServerOp for #op_enum {
-            fn max_reply_size(self) -> usize {
-                match self {
-                    #( #max_reply_size_cases )*
-                }
-            }
-
-            fn required_lease_count(self) -> usize {
-                match self {
-                    #( #required_leases_cases )*
-                }
-            }
-        }
-    }
-}
-
-// `Name` is only mutable as it contains `OnceCell`s, but they don't effect its
-// `Hash`, `PartialEq`, `Eq`, `Ord`, or `PartialOrd` implementations. So, it can
-// safely be used as a map key.
-#[allow(clippy::mutable_key_type)]
-pub fn generate_server_in_order_trait(
-    iface: &syntax::Interface,
-    allowed_callers: &BTreeMap<String, Vec<usize>>,
-) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
-    // Ensure any operations listed in `allowed_callers` actually exist for this
-    // server.
-    for opname in allowed_callers.keys() {
-        if !iface.ops.contains_key(opname.as_str()) {
-            return Err(Box::from(format!(
-                "allowed_callers operation `{}` does not exist for this server",
-                opname
-            )));
-        }
-    }
-
-    let iface_name = &iface.name;
-    let trt = format_ident!("InOrder{iface_name}Impl");
-    let trait_def = generate_trait_def(iface, &trt);
-
-    let enum_name = iface.name.as_op_enum();
-    let op_cases = iface.ops.iter().map(|(opname, op)| {
-        let check_allowed = if let Some(allowed_callers) = allowed_callers.get(opname.as_str()) {
-            // With our current optimization settings and rustc/llvm version,
-            // the compiler generates better code for raw `if` checks than it
-            // does for the more general `[T;N].contains(&T)`. We'll do a bit of
-            // manual optimization here; if `allowed_callers` is less than 4
-            // (which we expect it to be basically always), we'll generate a
-            // suitable `if`. For longer allowed_callers lists, we'll fall back
-            // to `[T;N].contains(&T)`, which produces a loop.
-            let cond = if allowed_callers.len() < 4 {
-                quote! {
-                    {
-                        let sender = rm.sender.index();
-                        #( sender != #allowed_callers )&&*
-                    }
-                }
-            } else {
-                quote! {
-                    ![#( #allowed_callers ),*].contains(&rm.sender.index())
-                }
-            };
-            quote! {
-                // Clippy doesn't like when the block generated by the len < 4
-                // case is in the if condition, so assign it to a variable.
-                let disallowed = #cond;
-                if disallowed {
-                    return Err(idol_runtime::RequestError::Fail(
-                        idol_runtime::ClientError::AccessViolation
-                    ));
-                }
-            }
-        } else {
-            quote!{}
-        };
-        let read = {
-            let arg_var = if op.args.is_empty() {
-                quote! { _ }
-            } else {
-                quote! { args }
-            };
-            let readfn = format_ident!("read_{opname}_msg");
-            quote! {
-                let #arg_var = #readfn(incoming).ok_or_else(|| {
-                    idol_runtime::ClientError::BadMessageContents.fail()
-                })?;
-            }
-        };
-        let args = op.args.iter().map(|(argname, arg)| {
-            match &arg.recv {
-                syntax::RecvStrategy::FromBytes => {
-                    let thingy = if arg.ty.is_bool() {
-                        quote! { #argname() }
-                    } else {
-                        quote! { #argname }
-                    };
-                    quote! {
-                        args.#thingy,
-                    }
-                },
-                syntax::RecvStrategy::From(_, None) => {
-                    let name = argname.raw_prefixed();
-                    quote! {
-                        args.#name.into(),
-                    }
-                }
-                syntax::RecvStrategy::From(_, Some(f)) => {
-                    let name = argname.raw_prefixed();
-                    quote! {
-                        #f(args.#name),
-                    }
-                }
-                syntax::RecvStrategy::FromPrimitive(_) => {
-                    quote! {
-                        args.#argname().ok_or_else(|| {
-                            idol_runtime::ClientError::BadMessageContents.fail()
-                        })?,
-                    }
-                }
-            }
-        });
-        let leases = op.leases.iter().enumerate().map(|(i, (leasename, lease))| {
-            // This is gross, but, let's spot us some slices :-(
-            let fun = match (lease.read, lease.write) {
-                (true, false) => "read_only",
-                (false, true) => "write_only",
-                (true, true) => "read_write",
-                _ => unreachable!(),
-            };
-
-            let (fun, limit) = if lease.ty.appears_unsized() {
-                let max_len = if let Some(n) = lease.max_len {
-                    // It's ok to unwrap the value in server code because we've
-                    // just gotten it _out of_ a NonZeroU32 here, so we know
-                    // it'll be statically valid.
-                    let n = n.get();
-                    quote! {
-                        , Some(core::num::NonZeroU32::new(#n).unwrap_lite())
-                    }
-                } else {
-                    quote!{ , None }
+            let leases = op.leases.iter().enumerate().map(|(i, (leasename, lease))| {
+                // This is gross, but, let's spot us some slices :-(
+                let fun = match (lease.read, lease.write) {
+                    (true, false) => "read_only",
+                    (false, true) => "write_only",
+                    (true, true) => "read_write",
+                    _ => unreachable!(),
                 };
-                (format_ident!("{fun}_slice"), max_len)
-            } else if lease.max_len.is_some() {
-                panic!(
-                    "Lease {i} ({leasename}) on operation {iface_name}.{opname} \
-                    has sized type but also max_len field"
-                );
-            } else {
-                (format_ident!("{fun}"), quote!{} )
-            };
-            let maybe_unwrap = if lease.max_len.is_some() {
-                quote! { .try_into().unwrap_lite() }
-            } else {
-                quote!{}
-            };
-            quote! {
-                idol_runtime::Leased::#fun(rm.sender, #i #limit)
-                    .ok_or_else(|| idol_runtime::ClientError::BadLease.fail())?#maybe_unwrap,
-            }
-        });
-        let reply = {
-            let encode = match op.encoding {
-                syntax::Encoding::Zerocopy => quote! {
-                    userlib::sys_reply(rm.sender, 0, zerocopy::AsBytes::as_bytes(&val));
-                },
-                syntax::Encoding::Hubpack | syntax::Encoding::Ssmarshal => {
-                    let reply_size = opname.as_reply_size();
-                    let serializer = op.encoding.crate_name();
-                    quote! {
-                        let mut reply_buf = [0u8; #reply_size];
-                        let n_reply = #serializer::serialize(&mut reply_buf, &val).map_err(|_| ()).unwrap_lite();
-                        userlib::sys_reply(rm.sender, 0, &reply_buf[..n_reply]);
-                    }
-                }
-            };
-            match &op.reply {
-                syntax::Reply::Simple(_) => quote! {
-                    match r {
-                        Ok(val) => {
-                            #encode
-                            Ok(())
+
+                let (fun, limit) = if lease.ty.appears_unsized() {
+                    let max_len = if let Some(n) = lease.max_len {
+                        // It's ok to unwrap the value in server code because we've
+                        // just gotten it _out of_ a NonZeroU32 here, so we know
+                        // it'll be statically valid.
+                        let n = n.get();
+                        quote! {
+                            , Some(core::num::NonZeroU32::new(#n).unwrap_lite())
                         }
-                        // Simple returns can only return ClientError. The compiler
-                        // can't see this. Jump through some hoops:
-                        Err(val) => Err(val.map_runtime(|e| match e {})),
-                    }
-                },
-                syntax::Reply::Result{ err, .. } => {
-                    let err_case = match err {
-                        // It might be surprising, but to return a complex error
-                        // we need to behave very much like the reply code
-                        // above: rather than returning `Err`, we need to
-                        // perform an actual `sys_reply` and then return `Ok` to
-                        // avoid triggering the reply handling code in the
-                        // generic dispatch loop.
-                        //
-                        // So, the fact that this error returns `Ok` is not a
-                        // bug.
-                        syntax::Error::Complex (ty) =>  match op.encoding {
-                            syntax::Encoding::Hubpack => quote! {
-                                match val {
-                                    idol_runtime::RequestError::Fail(f) => {
-                                        // Note: because of the way `into_fault` works,
-                                        // if it returns None, we don't send a reply at
-                                        // all. This is because None indicates that the
-                                        // caller was restarted or otherwise crashed
-                                        if let Some(fault) = f.into_fault() {
-                                            userlib::sys_reply_fault(rm.sender, fault);
-                                        }
-                                    }
-                                    idol_runtime::RequestError::Runtime(e) => {
-                                        let mut reply_buf = [0u8; <#ty as hubpack::SerializedSize>::MAX_SIZE];
-                                        let n_reply = hubpack::serialize(&mut reply_buf, &e).map_err(|_| ()).unwrap_lite();
-                                        userlib::sys_reply(rm.sender, 1, &reply_buf[..n_reply]);
-                                    }
-                                }
-                                Ok(())
-                            },
-                            encoding => panic!("Complex error types not supported for {encoding:?} encoding"),
-                        },
-                        syntax::Error::CLike(_) => quote! {
-                            Err(val.map_runtime(u16::from))
-                        },
-                        syntax::Error::ServerDeath => quote! {
-                            Err(val.map_runtime(|e| match e {}))
-                        }
+                    } else {
+                        quote!{ , None }
                     };
-                    quote! {
+                    (format_ident!("{fun}_slice"), max_len)
+                } else if lease.max_len.is_some() {
+                    panic!(
+                        "Lease {i} ({leasename}) on operation {iface_name}.{opname} \
+                        has sized type but also max_len field"
+                    );
+                } else {
+                    (format_ident!("{fun}"), quote!{} )
+                };
+                let maybe_unwrap = if lease.max_len.is_some() {
+                    quote! { .try_into().unwrap_lite() }
+                } else {
+                    quote!{}
+                };
+                quote! {
+                    idol_runtime::Leased::#fun(rm.sender, #i #limit)
+                        .ok_or_else(|| idol_runtime::ClientError::BadLease.fail())?#maybe_unwrap,
+                }
+            });
+            let reply = {
+                let encode = match op.encoding {
+                    syntax::Encoding::Zerocopy => quote! {
+                        userlib::sys_reply(rm.sender, 0, zerocopy::AsBytes::as_bytes(&val));
+                    },
+                    syntax::Encoding::Hubpack | syntax::Encoding::Ssmarshal => {
+                        let reply_size = opname.as_reply_size();
+                        let serializer = op.encoding.crate_name();
+                        quote! {
+                            let mut reply_buf = [0u8; #reply_size];
+                            let n_reply = #serializer::serialize(&mut reply_buf, &val).map_err(|_| ()).unwrap_lite();
+                            userlib::sys_reply(rm.sender, 0, &reply_buf[..n_reply]);
+                        }
+                    }
+                };
+                match &op.reply {
+                    syntax::Reply::Simple(_) => quote! {
                         match r {
                             Ok(val) => {
                                 #encode
                                 Ok(())
                             }
-                            Err(val) => {
-                                #err_case
+                            // Simple returns can only return ClientError. The compiler
+                            // can't see this. Jump through some hoops:
+                            Err(val) => Err(val.map_runtime(|e| match e {})),
+                        }
+                    },
+                    syntax::Reply::Result{ err, .. } => {
+                        let err_case = match err {
+                            // It might be surprising, but to return a complex error
+                            // we need to behave very much like the reply code
+                            // above: rather than returning `Err`, we need to
+                            // perform an actual `sys_reply` and then return `Ok` to
+                            // avoid triggering the reply handling code in the
+                            // generic dispatch loop.
+                            //
+                            // So, the fact that this error returns `Ok` is not a
+                            // bug.
+                            syntax::Error::Complex (ty) =>  match op.encoding {
+                                syntax::Encoding::Hubpack => quote! {
+                                    match val {
+                                        idol_runtime::RequestError::Fail(f) => {
+                                            // Note: because of the way `into_fault` works,
+                                            // if it returns None, we don't send a reply at
+                                            // all. This is because None indicates that the
+                                            // caller was restarted or otherwise crashed
+                                            if let Some(fault) = f.into_fault() {
+                                                userlib::sys_reply_fault(rm.sender, fault);
+                                            }
+                                        }
+                                        idol_runtime::RequestError::Runtime(e) => {
+                                            let mut reply_buf = [0u8; <#ty as hubpack::SerializedSize>::MAX_SIZE];
+                                            let n_reply = hubpack::serialize(&mut reply_buf, &e).map_err(|_| ()).unwrap_lite();
+                                            userlib::sys_reply(rm.sender, 1, &reply_buf[..n_reply]);
+                                        }
+                                    }
+                                    Ok(())
+                                },
+                                encoding => panic!("Complex error types not supported for {encoding:?} encoding"),
+                            },
+                            syntax::Error::CLike(_) => quote! {
+                                Err(val.map_runtime(u16::from))
+                            },
+                            syntax::Error::ServerDeath => quote! {
+                                Err(val.map_runtime(|e| match e {}))
+                            }
+                        };
+                        quote! {
+                            match r {
+                                Ok(val) => {
+                                    #encode
+                                    Ok(())
+                                }
+                                Err(val) => {
+                                    #err_case
+                                }
                             }
                         }
                     }
                 }
-            }
-        };
-        quote! {
-            #enum_name::#opname => {
-                #check_allowed
-                #read
-                let r = self.1.#opname(
-                    rm,
-                    #( #args )*
-                    #( #leases )*
-                );
-                #reply
-            }
-        }
-    });
-    Ok(quote! {
-        #trait_def
-
-        #[automatically_derived]
-        impl <S: #trt> idol_runtime::Server<#enum_name> for (core::marker::PhantomData<#enum_name>, &'_ mut S) {
-            fn recv_source(&self) -> Option<userlib::TaskId> {
-                <S as #trt>::recv_source(self.1)
-            }
-
-            fn closed_recv_fail(&mut self) {
-                <S as #trt>::closed_recv_fail(self.1)
-            }
-            fn handle(
-                &mut self,
-                op: #enum_name,
-                incoming: &[u8],
-                rm: &userlib::RecvMessage,
-            ) -> Result<(), idol_runtime::RequestError<u16>> {
-                #[allow(unused_imports)]
-                use core::convert::TryInto;
-                match op {
-                    #( #op_cases )*
+            };
+            quote! {
+                #enum_name::#opname => {
+                    #check_allowed
+                    #read
+                    let r = self.1.#opname(
+                        rm,
+                        #( #args )*
+                        #( #leases )*
+                    );
+                    #reply
                 }
             }
-        }
-    })
+        });
+        Ok(quote! {
+            #trait_def
+
+            #[automatically_derived]
+            impl <S: #trt> idol_runtime::Server<#enum_name> for (core::marker::PhantomData<#enum_name>, &'_ mut S) {
+                fn recv_source(&self) -> Option<userlib::TaskId> {
+                    <S as #trt>::recv_source(self.1)
+                }
+
+                fn closed_recv_fail(&mut self) {
+                    <S as #trt>::closed_recv_fail(self.1)
+                }
+                fn handle(
+                    &mut self,
+                    op: #enum_name,
+                    incoming: &[u8],
+                    rm: &userlib::RecvMessage,
+                ) -> Result<(), idol_runtime::RequestError<u16>> {
+                    #[allow(unused_imports)]
+                    use core::convert::TryInto;
+                    match op {
+                        #( #op_cases )*
+                    }
+                }
+            }
+        })
+    }
+
 }
 
 fn generate_trait_def(


### PR DESCRIPTION
Currently, all code-generation in Idol is performed by free functions. This is problematic for adding new configuration parameters to the API, as adding an additional parameter to these functions is a breaking change, requiring "every build script in Hubris" to be updated. On the other hand, the current API surface already has a bunch of functions that essentially call another function with one parameter excluded, such as `build_server_support` and `build_restricted_server_support`; adding new parameters which are defaulted in this manner gets unwieldy very fast.

Therefore, this commit introduces a `Generator` type, which serves as a builder pattern for code generation settings. The bodies of the existing free functions have been moved to methods on `Generator`, with the free functions now being thin wrappers around
`Generator::default().<the_function>()`. This way, we can freely add any number of new configuration options to the `Generator` struct, without having to worry about breaking all callers of the code generation.

Right now the only parameter configured by `Generator` is whether or not to run `prettyplease` formatting on the generated code. In the future, it will also be used to configure automatic counter generation (this change was factored out from PR #41 to make that diff easier to review).