### PR TITLE
add feature flags for controlling counter codegen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,11 @@ name = "idol"
 version = "0.4.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# See more keys and their definitions at
+# https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+client-counters = []
+server-counters = []
 
 [dependencies]
 ron = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,6 @@ name = "idol"
 version = "0.4.0"
 edition = "2021"
 
-# See more keys and their definitions at
-# https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 client-counters = []
 server-counters = []

--- a/src/client.rs
+++ b/src/client.rs
@@ -71,7 +71,7 @@ impl Generator {
     ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let mut ops = Vec::with_capacity(iface.ops.len());
         let iface_name = &iface.name;
-        let counters = self.counters.clone().map(|ctrs| ctrs.client(iface));
+        let counters = self.counters.client(iface);
         for (idx, (name, op)) in iface.ops.iter().enumerate() {
             // Let's do some checks
             if op.idempotent {
@@ -87,7 +87,7 @@ impl Generator {
                 }
                 match &op.reply {
                     syntax::Reply::Result { err, .. }
-                        if matches!(err, syntax::Error::ServerDeath) => 
+                        if matches!(err, syntax::Error::ServerDeath) =>
                     {
                         return Err(
                             format!("idempotent operations should not indicate server death: {name}")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,20 +13,20 @@ pub use crate::counters::CounterSettings;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[must_use]
 pub struct Generator {
-    pub(crate) counters: Option<CounterSettings>,
+    pub(crate) counters: CounterSettings,
     pub(crate) fmt: bool,
 }
 
 impl Generator {
     pub fn new() -> Self {
         Self {
-            counters: None,
+            counters: Default::default(),
             fmt: true,
         }
     }
 
-    /// If [`Some`], configures how event counters will be generated for IPC
-    /// operations. If [`None`], no counters will be generated.
+    /// Overrides how how event counters will be generated for IPC
+    /// operations.
     ///
     /// By default, counters are not enabled.
     ///
@@ -42,12 +42,15 @@ impl Generator {
     /// ```
     ///
     ///
-    /// Disabling counters (this is equivalent to `Generator::default()`):
+    /// Disabling counters:
     ///
     /// ```
+    /// let counters = idol::CounterSettings::default()
+    ///     .with_client_counters(false)
+    ///     .with_server_counters(false);
     /// # let _ =
     /// idol::Generator::new()
-    ///     .with_counters(None)
+    ///     .with_counters(counters)
     /// # ;
     /// ```
     ///
@@ -62,11 +65,7 @@ impl Generator {
     ///     .with_counters(counters)
     /// # ;
     /// ```
-    pub fn with_counters(
-        self,
-        counters: impl Into<Option<CounterSettings>>,
-    ) -> Self {
-        let counters = counters.into();
+    pub fn with_counters(self, counters: CounterSettings) -> Self {
         Self { counters, ..self }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -412,7 +412,7 @@ impl Generator {
         let iface_name = &iface.name;
         let trt = format_ident!("InOrder{iface_name}Impl");
         let trait_def = generate_trait_def(iface, &trt);
-        let counters = self.counters.clone().map(|ctrs| ctrs.server(iface));
+        let counters = self.counters.server(iface);
 
         let enum_name = iface.name.as_op_enum();
         let op_cases = iface.ops.iter().map(|(opname, op)| {


### PR DESCRIPTION
This commit adds "client-counters" and "server-counters" feature flags to the `idol` crate to enable the generation of IPC client and server counters. This is a bit easier than doing it in the build script, as it allows the top-level task to control whether it generates client counters, rather than the crate defining the client stub. In particular, a task that depends on many client stub crates can enable counter generation in one place, by setting the feature on its `idol` dep, without having to manually enumerate all of its client stub dependencies.

The `CounterSettings` type can still be used to manually override these features.