### PR TITLE
fix compilation error in #44

### DIFF
--- a/src/counters.rs
+++ b/src/counters.rs
@@ -59,7 +59,7 @@ impl CounterSettings {
         }
     }
 
-    pub(crate) fn server(self, iface: &syntax::Interface) -> Option<Counters> {
+    pub(crate) fn server(&self, iface: &syntax::Interface) -> Option<Counters> {
         if !self.server_counters {
             return None;
         }
@@ -96,10 +96,10 @@ impl CounterSettings {
                 ClientError(#[count(children)] idol_runtime::ClientError)
             })
         };
-        Some(Counters::new(self, iface, variants, true))
+        Some(Counters::new(self.clone(), iface, variants, true))
     }
 
-    pub(crate) fn client(self, iface: &syntax::Interface) -> Option<Counters> {
+    pub(crate) fn client(&self, iface: &syntax::Interface) -> Option<Counters> {
         if !self.client_counters {
             return None;
         }
@@ -119,7 +119,7 @@ impl CounterSettings {
                 }
             }
         });
-        Counters::new(self, iface, variants, false)
+        Some(Counters::new(self.clone(), iface, variants, false))
     }
 }
 


### PR DESCRIPTION
Whoops, it looks like PR #44 broke the build. My bad --- I had mistakenly assumed that we had a CI job that ensured that `idol` builds, so I hadn't noticed that I introduced a compilation error. I'll go ahead and set up CI builds for this repo, in a separate branch.