### PR TITLE
fix `#[ount(children)]`

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -93,7 +93,7 @@ impl From<ClientError> for u32 {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Count)]
 #[repr(u32)]
 pub enum RequestError<E> {
-    Runtime(#[ount(children)] E),
+    Runtime(#[count(children)] E),
     Fail(#[count(children)] ClientError),
 }
 


### PR DESCRIPTION
I really thought I'd pushed this to #47, but it looks like it somehow didn't get pushed --- I had the commit staged all along. My bad. Sorry.