### PR TITLE
idol: API to derive additional traits for op enums

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -58,7 +58,7 @@ impl Generator {
         iface: &syntax::Interface,
         mut out: impl std::io::Write,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let mut tokens = common::generate_op_enum(iface);
+        let mut tokens = self.generate_op_enum(iface);
         tokens.extend(self.client_stub_tokens(iface)?);
         let formatted = common::fmt_tokens(tokens)?;
         write!(out, "{formatted}")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,14 @@ pub use crate::counters::CounterSettings;
 pub struct Generator {
     pub(crate) counters: CounterSettings,
     pub(crate) fmt: bool,
+    pub(crate) extra_op_enum_derives: Vec<syn::Path>,
 }
 
 impl Generator {
     pub fn new() -> Self {
         Self {
             counters: Default::default(),
+            extra_op_enum_derives: Vec::new(),
             fmt: true,
         }
     }
@@ -72,6 +74,34 @@ impl Generator {
     /// If `true`, generated code will be formatted with `prettyplease`.
     pub fn with_fmt(self, fmt: bool) -> Self {
         Self { fmt, ..self }
+    }
+
+    /// Add additional traits to derive for the generated operation enum.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # let _ =
+    /// idol::Generator::new().with_op_enum_derives(&[
+    ///     "serde::Serialize",
+    ///    "serde::Deserialize",
+    /// ])
+    /// #;
+    /// ```
+    pub fn with_op_enum_derives<T>(
+        self,
+        derives: impl IntoIterator<Item = T>,
+    ) -> Result<Self, syn::Error>
+    where
+        T: AsRef<str>,
+    {
+        Ok(Self {
+            extra_op_enum_derives: derives
+                .into_iter()
+                .map(|s| syn::parse_str(s.as_ref()))
+                .collect::<Result<_, _>>()?,
+            ..self
+        })
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -95,7 +95,7 @@ impl Generator {
 
         tokens.extend(self.generate_server_constants(iface));
         tokens.extend(self.generate_server_conversions(iface));
-        tokens.extend(common::generate_op_enum(iface));
+        tokens.extend(self.generate_op_enum(iface));
         tokens.extend(self.generate_server_op_impl(iface));
 
         tokens.extend(match style {


### PR DESCRIPTION
This commit adds a new API to `idol::Generator` to add a list of additional traits to derive for the generated `Operation` enum type. This is motivated by the desire to derive `counters::Count` for the `SpiOperation` enum, as it's used in ringbuf entries in `drv-stm32xx-spi-server-core`, which I would like to be able to count occurences of. But, it may be useful for other purposes as well.