### PR TITLE
A collection of improvements to generated code size

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -413,8 +413,11 @@ impl Generator {
                                 quote! { return <#t as userlib::FromPrimitive>::#from_prim(v).unwrap_lite(); }
                             }
                         };
+                        // We're going to assume rc is zero at this point since
+                        // we've already extracted the server death case. This
+                        // avoids an otherwise-hard-to-avoid client panic site
+                        // that doesn't happen in practice.
                         quote! {
-                            if rc != 0 { panic!(); }
                             #decode
                             #count
                             #ret

--- a/src/client.rs
+++ b/src/client.rs
@@ -387,7 +387,13 @@ impl Generator {
 
                 match &op.reply {
                     syntax::Reply::Simple(t) => {
-                        let decode = gen_decode(t);
+                        let mut decode = gen_decode(t);
+                        if let syn::Type::Tuple(tt) = &t.ty.0 {
+                            if tt.elems.is_empty() {
+                                // Override for the `Simple("()")` case.
+                                decode = quote::quote! { let v = (); };
+                            }
+                        }
                         let count = match counters {
                             Some(ref ctrs) => ctrs.count_simple_op(name),
                             None => quote! {},


### PR DESCRIPTION
This is part of my hunt for "systemic" sources of size bloat that I can fix centrally.

Fixes here are:

1. In the server runtime, server impls that do not override `recv_source` (which is the vast majority of them!) no longer generate a runtime-unreachable panic for a closed receive failure, since they cannot actually issue a closed receive.
2. In the server runtime, clients that send overlong messages are now faulted without any possibility of panicking the server, removing a mostly-unreachable panic site.
3. In the client stubs, the return code from operations that "cannot fail" is no longer checked. This technically can miss cases where we call the wrong task (due to some sort of gross misconfiguration), but the previous check wasn't actually sufficient to detect that reliably, and was costing a panic site at every client call site.
4. In the client stubs, we no longer use ssmarshal/hubpack to deserialize `()`. Deserializing `()` is a no-op but still compiled in a panic, because we sliced an array to do it and the compiler couldn't tell that the value we were using to slice was (at runtime) always zero.