### PR TITLE
server: restore internal _args variable

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -107,8 +107,10 @@ impl Generator {
         Ok(tokens)
     }
 
-
-    pub fn generate_server_constants(&self, iface: &syntax::Interface) -> TokenStream {
+    pub fn generate_server_constants(
+        &self,
+        iface: &syntax::Interface,
+    ) -> TokenStream {
         // Generate message sizing constants for each message.
         let mut msgsize_names = Vec::with_capacity(iface.ops.len());
         let consts = iface.ops.iter().map(|(name, op)| {
@@ -202,7 +204,10 @@ impl Generator {
         }
     }
 
-    pub fn generate_server_conversions(&self, iface: &syntax::Interface) -> TokenStream {
+    pub fn generate_server_conversions(
+        &self,
+        iface: &syntax::Interface,
+    ) -> TokenStream {
         let conversions = iface.ops.iter().map(|(name, op)| {
             // Define args struct.
                 let attrs = match op.encoding {
@@ -296,7 +301,7 @@ impl Generator {
                 } else {
                     quote! {}
                 };
-    
+
                 let read_fn = {
                     let read_fn = format_ident!("read_{}_msg", name);
                     match op.encoding {
@@ -361,7 +366,10 @@ impl Generator {
         }
     }
 
-    pub fn generate_server_op_impl(&self, iface: &syntax::Interface) -> TokenStream {
+    pub fn generate_server_op_impl(
+        &self,
+        iface: &syntax::Interface,
+    ) -> TokenStream {
         let op_enum = iface.name.as_op_enum();
         let max_reply_size_cases = iface.ops.keys().map(|opname| {
             let reply_size = opname.as_reply_size();
@@ -451,7 +459,12 @@ impl Generator {
             };
             let read = {
                 let arg_var = if op.args.is_empty() {
-                    quote! { _ }
+                    // DO NOT GIVE IN TO THE TEMPTATION TO MAKE THIS _
+                    //
+                    // _ and _x have different semantics in Rust, and _ makes
+                    // the compiler a lot more aggressive about eliminating the
+                    // args type from the DWARF!
+                    quote! { _args }
                 } else {
                     quote! { args }
                 };
@@ -743,7 +756,7 @@ fn generate_trait_def(
                 quote! { Result<#ok, idol_runtime::RequestError<#err_ty>> }
             },
             syntax::Reply::Simple(t) => {
-                quote! { 
+                quote! {
                     Result<#t, idol_runtime::RequestError<core::convert::Infallible>>
                 }
             },

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -603,9 +603,9 @@ mod tests {
         "#;
 
         let err = Interface::from_str(HAS_DUPES).unwrap_err();
-        assert!(
-            err.to_string().starts_with("invalid entry: found duplicate key")
-        );
+        assert!(err
+            .to_string()
+            .starts_with("invalid entry: found duplicate key"));
     }
 
     #[test]
@@ -630,9 +630,9 @@ mod tests {
         "#;
 
         let err = Interface::from_str(HAS_DUPES).unwrap_err();
-        assert!(
-            err.to_string().starts_with("invalid entry: found duplicate key")
-        );
+        assert!(err
+            .to_string()
+            .starts_with("invalid entry: found duplicate key"));
     }
 
     #[test]
@@ -660,8 +660,8 @@ mod tests {
         "#;
 
         let err = Interface::from_str(HAS_DUPES).unwrap_err();
-        assert!(
-            err.to_string().starts_with("invalid entry: found duplicate key")
-        );
+        assert!(err
+            .to_string()
+            .starts_with("invalid entry: found duplicate key"));
     }
 }


### PR DESCRIPTION
This got changed to let _ = foo, which is great and correct.

However, it also causes current versions of rustc to become more aggressive about not emitting the type in the DWARF, and this makes Humility very sad.

I'm also patching Humility but, this fixes the code generator for older versions of Humility.

This is the proximal cause of: https://github.com/oxidecomputer/hubris/issues/1777