### PR TITLE
support `Complex` errors with `encoding: Zerocopy`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -369,14 +369,14 @@ impl Generator {
                     quote! {
                         let _len = len;
                         #[derive(
-                            zerocopy_derive::FromBytes,
+                            zerocopy_derive::TryFromBytes,
                             zerocopy_derive::Unaligned,
                         )]
                         #[repr(C, packed)]
                         struct #reply_ty {
                             value: #repr_ty,
                         }
-                        let v: #repr_ty = zerocopy::FromBytes::read_from_bytes(&reply[..]).unwrap_lite();
+                        let v: #repr_ty = zerocopy::TryFromBytes::read_from_bytes(&reply[..]).unwrap_lite();
                     }
                 };
                 let gen_decode = |t: &syntax::AttributedTy| match op.encoding {

--- a/src/client.rs
+++ b/src/client.rs
@@ -376,7 +376,7 @@ impl Generator {
                         struct #reply_ty {
                             value: #repr_ty,
                         }
-                        let v: #repr_ty = zerocopy::TryFromBytes::read_from_bytes(&reply[..]).unwrap_lite();
+                        let v: #repr_ty = zerocopy::TryFromBytes::try_read_from_bytes(&reply[..]).unwrap_lite();
                     }
                 };
                 let gen_decode = |t: &syntax::AttributedTy| match op.encoding {

--- a/src/client.rs
+++ b/src/client.rs
@@ -377,7 +377,7 @@ impl Generator {
                             value: #repr_ty,
                         }
                         let v: #repr_ty = zerocopy::FromBytes::read_from_bytes(&reply[..]).unwrap_lite();
-
+                    }
                 };
                 let gen_decode = |t: &syntax::AttributedTy| match op.encoding {
                     syntax::Encoding::Zerocopy => {
@@ -491,7 +491,7 @@ impl Generator {
                                         quote! {
                                             let (v, _): (#ty, _) = hubpack::deserialize(&reply[..len]).unwrap_lite();
                                         }
-                                    },
+                                    }
                                     syntax::Encoding::Zerocopy => {
                                         gen_zerocopy_decode(ty, "ERROR")
                                     }
@@ -508,9 +508,7 @@ impl Generator {
                                     }
                                     None => quote! {},
                                 };
-                                let check_server_death = if op
-                                    .idempotent
-                                {
+                                let check_server_death = if op.idempotent {
                                     // Idempotent ops already checked for server death
                                     // above.
                                     quote! {}

--- a/src/server.rs
+++ b/src/server.rs
@@ -608,7 +608,7 @@ impl Generator {
                                     },
                                     syntax::Encoding::Zerocopy => quote! {
                                         userlib::sys_reply(rm.sender, 1, zerocopy::IntoBytes::as_bytes(&e));
-                                    }
+                                    },
                                     encoding => panic!("Complex error types not supported for {encoding:?} encoding"),
                                 };
                                 quote! {


### PR DESCRIPTION
PR #57 updated `idol` to generate code using `zerocopy` v0.8.x rather than v0.6.x. With the addition of the `TryFromBytes` trait, the new `zerocopy` release now has support for data-bearing enums (with some limitations due to padding bytes). Therefore, we can now support `zerocopy` as an encoding for `Complex` error types provided they satisfy the requirements to derive `IntoBytes` and `TryFromBytes`. This branch changes `encoding: Zerocopy` IPC responses to support the `Complex` error type provided that the error derives the appropriate error traits, rather than failing.

Fixes #58 