### PR TITLE
Generate `FailServer` when possible

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-01"
+channel = "nightly-2024-09-17"
 targets = [ "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf" ]
 profile = "minimal"
 components = [ "rustfmt" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,18 @@ pub struct Generator {
     pub(crate) counters: CounterSettings,
     pub(crate) fmt: bool,
     pub(crate) extra_op_enum_derives: Vec<syn::Path>,
+    pub(crate) error_server: GenerateErrorServer,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+enum GenerateErrorServer {
+    /// Do not generate an error server under any circumstances
+    No,
+    /// Generate an error server if all functions have the same error type
+    #[default]
+    Maybe,
+    /// Generate an error server; fail if functions have different error types
+    Yes,
 }
 
 impl Generator {
@@ -24,6 +36,7 @@ impl Generator {
             counters: Default::default(),
             extra_op_enum_derives: Vec::new(),
             fmt: true,
+            error_server: Default::default(),
         }
     }
 
@@ -74,6 +87,22 @@ impl Generator {
     /// If `true`, generated code will be formatted with `prettyplease`.
     pub fn with_fmt(self, fmt: bool) -> Self {
         Self { fmt, ..self }
+    }
+
+    /// Disables error server generation
+    pub fn without_error_server(self) -> Self {
+        Self {
+            error_server: GenerateErrorServer::No,
+            ..self
+        }
+    }
+
+    /// Enables mandatory error server generation
+    pub fn with_error_server(self) -> Self {
+        Self {
+            error_server: GenerateErrorServer::Yes,
+            ..self
+        }
     }
 
     /// Add additional traits to derive for the generated operation enum.

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -496,7 +496,7 @@ impl quote::ToTokens for Ty {
 
 /// Enumerates different ways that an error type might be passed through the
 /// REPLY syscall.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Error {
     /// The error type should be created from the (non-zero) return code only.
     /// The reply message in error cases is expected to be zero-length.


### PR DESCRIPTION
If every method on an interface returns the same error type, then we can generate a `FailServer` which always returns an error.  This is useful for cases where we have permanently failed but do not want to panic, e.g. https://github.com/oxidecomputer/hubris/issues/994