### PR TITLE
Fix Clippy lint

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -760,7 +760,7 @@ impl Generator {
                     #( #args )*
                     #( #leases )*
                 ) -> Result<#ok, idol_runtime::RequestError<#err>> {
-                    return Err(self.err.into())
+                    Err(self.err.into())
                 }
             }
         });


### PR DESCRIPTION
We passed `cargo check`, but `clippy` has opinions on unnecessary returns!