### PR TITLE
Update toolchain to `nightly-2025-07-20`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-09-17"
+channel = "nightly-2025-07-20"
 targets = [ "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf" ]
 profile = "minimal"
 components = [ "rustfmt" ]

--- a/src/client.rs
+++ b/src/client.rs
@@ -627,7 +627,6 @@ impl Generator {
                     // expressions.
                     unused_braces,
                     unused_parens)]
-            #[automatically_derived]
             impl #iface_name {
                 #(#ops)*
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -375,6 +375,7 @@ impl Generator {
                                 zerocopy_derive::Unaligned,
                             )]
                             #[repr(C, packed)]
+                            #[allow(dead_code)] // Used by Humility
                             struct #reply_ty {
                                 value: #repr_ty,
                             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -365,19 +365,9 @@ impl Generator {
             let reply = {
                 let gen_decode = |t: &syntax::AttributedTy| match op.encoding {
                     syntax::Encoding::Zerocopy => {
-                        let reply_ty =
-                            quote::format_ident!("{iface_name}_{name}_REPLY");
                         let repr_ty = t.repr_ty();
                         quote! {
                             let _len = len;
-                            #[derive(
-                                zerocopy_derive::FromBytes,
-                                zerocopy_derive::Unaligned,
-                            )]
-                            #[repr(C, packed)]
-                            struct #reply_ty {
-                                value: #repr_ty,
-                            }
                             let v: #repr_ty = zerocopy::FromBytes::read_from_bytes(&reply[..]).unwrap_lite();
                         }
                     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -365,9 +365,19 @@ impl Generator {
             let reply = {
                 let gen_decode = |t: &syntax::AttributedTy| match op.encoding {
                     syntax::Encoding::Zerocopy => {
+                        let reply_ty =
+                            quote::format_ident!("{iface_name}_{name}_REPLY");
                         let repr_ty = t.repr_ty();
                         quote! {
                             let _len = len;
+                            #[derive(
+                                zerocopy_derive::FromBytes,
+                                zerocopy_derive::Unaligned,
+                            )]
+                            #[repr(C, packed)]
+                            struct #reply_ty {
+                                value: #repr_ty,
+                            }
                             let v: #repr_ty = zerocopy::FromBytes::read_from_bytes(&reply[..]).unwrap_lite();
                         }
                     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -558,6 +558,7 @@ impl Generator {
 
                         // If the operation is idempotent but failed due to server death, retry.
                         if let Some(g) = userlib::extract_new_generation(rc) {
+                            let _len = len;
                             self.current_id.set(userlib::TaskId::for_index_and_gen(task.index(), g));
                             continue;
                         }

--- a/src/counters.rs
+++ b/src/counters.rs
@@ -172,8 +172,7 @@ impl Counters {
         quote! {
             #enum_def
 
-            static #counters_static: <#event_enum as counters::Count>::Counters =
-                <#event_enum as counters::Count>::NEW_COUNTERS;
+            counters::counters!(#counters_static, #event_enum);
         }
     }
 

--- a/src/counters.rs
+++ b/src/counters.rs
@@ -172,7 +172,6 @@ impl Counters {
         quote! {
             #enum_def
 
-            #[used]
             static #counters_static: <#event_enum as counters::Count>::Counters =
                 <#event_enum as counters::Count>::NEW_COUNTERS;
         }


### PR DESCRIPTION
This branch updates `idol` to a recent toolchain, `nightly-2025-07-20`.
In order to generate code that compiles without warnings on this
toolchain, it was necessary to change a few things. 

`idol` used to put the `#[automatically_derived]` attribute on all
generated `impl` blocks. At some point between the previous ancient
toolchain and the one from a couple days ago, this attribute was changed
to only work on _trait impls_ and not _inherent impls_, and placing it
on inherent impls emits a warning. The server codegen only generates
trait impls, but the client code also generates an inherent impl for the
client struct (which is where most of the action happens), and it was
thus necessary  to remove the attribute from this. One of the things
`#[automatically_derived]` does is to suppress dead code and unused
variable warnings. Now that these warnings are no longer suppressed in
the client impl, some dead code and unused variables had to be removed
to make these warnings go away. In particular, it turns out that the
`<Name_of_interface>_<name_of_ipc>_REPLY` structs we used to generate
with zerocopy IPC clients were totally unused, so I got rid of them.

Additionally, I've changed the codegen for IPC counters to just use the
`counters!` macro to generate the static, instead of reimplementing it
in `idol` codegen. This way, we get whatever the `counters!` macro
generates, instead of having to keep it in sync. In particular, this
lets us benefit from the change to remove the `#[used]` attribute from
counters that was made in oxidecomputer/hubris#2167. Otherwise, it would
have been necessary to also remove that attribute from `idol`'s
reimplementation of the counters static generation.