### PR TITLE
Fix client codegen for `Result<bool, ..>`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -442,7 +442,11 @@ impl Generator {
                         let decode = gen_decode(ok);
                         let ret_ok = match &ok.recv {
                             syntax::RecvStrategy::FromBytes
-                                if ok.ty.is_bool() =>
+                                if ok.ty.is_bool()
+                                    && matches!(
+                                        op.encoding,
+                                        syntax::Encoding::Zerocopy
+                                    ) =>
                             {
                                 quote! { return Ok(v != 0); }
                             }


### PR DESCRIPTION
Same as #67, but for `Result<bool, ..>`

Previously, we generated code that looked like
```rust
if rc == 0 {
    let (v, _): (bool, _) = hubpack::deserialize(&reply[..len]).unwrap_lite();
    counters::count!(__PINS_CLIENT_COUNTERS, PinsEvent::pint_detect(Ok(())));
    return Ok(v != 0);
} else {
    // ... etc
```
(which obviously doesn't compile)