### PR TITLE
runtime: check lease count while validating IPC

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -287,6 +287,11 @@ pub fn dispatch<S: NotificationHandler, Op: ServerOp>(
         return;
     }
 
+    if rm.lease_count != op.required_lease_count() {
+        sys_reply_fault(rm.sender, ReplyFaultReason::BadLeases);
+        return;
+    }
+
     match server.handle(op, incoming, &rm) {
         Ok(()) => {
             // stub has taken care of it.


### PR DESCRIPTION
The metadata generator records a `required_lease_count` for each IPC operation, and I swear that the server code used to check it ...

... but currently it does not. This means that you can send an IPC to a server with the wrong number of leases, and depending on the code path, you can arrange to crash the server. The reason: the server assumes the leases exist (runtime was supposed to check!) and passes nonexistent leases indices to sys_borrow_info.

Hubris syscalls are notoriously prone to murder when passed obviously valid inputs, and this is no exception.

This commit adds (restores?) the check.