### PR TITLE
Remove unnecessary map_err

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -576,7 +576,7 @@ impl Generator {
                         let serializer = op.encoding.crate_name();
                         quote! {
                             let mut reply_buf = [0u8; #reply_size];
-                            let n_reply = #serializer::serialize(&mut reply_buf, &val).map_err(|_| ()).unwrap_lite();
+                            let n_reply = #serializer::serialize(&mut reply_buf, &val).unwrap_lite();
                             userlib::sys_reply(rm.sender, 0, &reply_buf[..n_reply]);
                         }
                     }
@@ -625,7 +625,7 @@ impl Generator {
                                         }
                                         idol_runtime::RequestError::Runtime(e) => {
                                             let mut reply_buf = [0u8; <#ty as hubpack::SerializedSize>::MAX_SIZE];
-                                            let n_reply = hubpack::serialize(&mut reply_buf, &e).map_err(|_| ()).unwrap_lite();
+                                            let n_reply = hubpack::serialize(&mut reply_buf, &e).unwrap_lite();
                                             userlib::sys_reply(rm.sender, 1, &reply_buf[..n_reply]);
                                         }
                                     }


### PR DESCRIPTION
`UnwrapLite`/`unwrap_lite` is implemented for all `E`s:

https://github.com/oxidecomputer/hubris/blob/ad8885134aa77353ae4c3db0c9d09cdaba4f9f19/lib/unwrap-lite/src/lib.rs#L18-L29

This means that the extra `map_err(|_| ())` (which could also be `map_err(drop)` isn't necessary. I was *somewhat* wondering whether this could lead to monomorphization bloat, however this extension method is `inline(always)`, and at least as a before/after snapshot as of today, doesn't have any meaningful change in an app-sized project:

```
# before
Finished `release` profile [optimized + debuginfo] target(s) in 0.12s
target/thumbv7em-none-eabihf/release/cosmo -> target/cosmo-b-dev/dist/kernel
flash     = 0x08000000..0x08100000
axi_sram  = 0x24000000..0x24080000
dtcm      = 0x20000000..0x20020000
sram1_mac = 0x30000000..0x30010000
sram1     = 0x30010000..0x30020000
sram2     = 0x30020000..0x30040000
sram3     = 0x30040000..0x30048000
sram4     = 0x38000000..0x38010000
bank2     = 0x08100000..0x08200000
Used:
flash:     0xb4b00 (70%)
axi_sram*: 0x4fa20 (62%)
dtcm:      0x10800 (51%)
sram1_mac: 0x4000 (25%)
sram1:     extern region (jefe, dump_agent)
sram2:     extern region (jefe, dump_agent)
sram3:     extern region (jefe, dump_agent)
sram4:     extern region (jefe, dump_agent)
bank2:     extern region (update_server)
*default ram region
warning: memory allocation is sub-optimal
Suggested improvements:
kernel:
axi_sram:  6736  (currently 8192)
```


```
# after, with this idolatry change
target/thumbv7em-none-eabihf/release/cosmo -> target/cosmo-b-dev/dist/kernel
flash     = 0x08000000..0x08100000
axi_sram  = 0x24000000..0x24080000
dtcm      = 0x20000000..0x20020000
sram1_mac = 0x30000000..0x30010000
sram1     = 0x30010000..0x30020000
sram2     = 0x30020000..0x30040000
sram3     = 0x30040000..0x30048000
sram4     = 0x38000000..0x38010000
bank2     = 0x08100000..0x08200000
Used:
  flash:     0xb4b00 (70%)
  axi_sram*: 0x4fa20 (62%)
  dtcm:      0x10800 (51%)
  sram1_mac: 0x4000 (25%)
  sram1:     extern region (jefe, dump_agent)
  sram2:     extern region (jefe, dump_agent)
  sram3:     extern region (jefe, dump_agent)
  sram4:     extern region (jefe, dump_agent)
  bank2:     extern region (update_server)
    *default ram region
warning: memory allocation is sub-optimal
Suggested improvements:
kernel:
  axi_sram:  6736  (currently 8192)
```

This is not an important or meaningful change, just an oddity I noticed while reviewing the generated code.